### PR TITLE
feat: add proof in api documentation

### DIFF
--- a/api-documentation/issue-api.yaml
+++ b/api-documentation/issue-api.yaml
@@ -19,7 +19,7 @@ tags:
 - name: Verifying
   description: The following APIs are defined for verifying a Verifiable Credential
 paths:
-  /credentials/claim:
+  /credentials/issue:
     post:
       tags:
         - Issuing
@@ -31,40 +31,6 @@ paths:
           'appliation/json':
             schema:
               $ref: '#/components/schemas/credentialRequest'
-        required: true
-      responses:
-        201:
-          description: Credential successfully issued!
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/credentialResponse'
-        400:
-          description: Invalid Input
-          content: {}
-        500:
-          description: error
-          content: {}
-      x-codegen-request-body-name: body
-  /credentials/sign:
-    post:
-      tags:
-        - Issuing
-      summary: Credential sign API
-      operationId: credentialSign
-      requestBody:
-        description: Credential payload
-        content:
-          'appliation/json':
-            schema:
-              allOf:
-                - type: object
-                  properties:
-                    credentialId:
-                      type: string
-                      example: credentialDID
-                      description: Optional field, required if a claim is already made
-                - $ref: '#/components/schemas/credentialRequest'
         required: true
       responses:
         201:

--- a/api-documentation/issue-api.yaml
+++ b/api-documentation/issue-api.yaml
@@ -376,6 +376,30 @@ components:
         credentialSubject:
           type: object
           properties: {}
+        proof:
+          type: object
+          properties: 
+            type:
+              type: string
+            created:
+              type: string
+              format: 'date-time'
+            challenge:
+              type: string
+            domain:
+              type: string
+            nonce:
+              type: string
+            verificationMethod:
+              type: string
+            proofPurpose:
+              type: string
+            jws:
+              type: string
+            proofValue:
+              type: string
+            
+
       
   securitySchemes:
     Authorization:

--- a/api-documentation/issue-api.yaml
+++ b/api-documentation/issue-api.yaml
@@ -115,7 +115,7 @@ paths:
           content:
             'appliation/json':
               schema:
-                $ref: '#/components/schemas/verifiableCredentialType'
+                $ref: '#/components/schemas/verifiableCredential'
         401:
           description: Not Authorized
           content: {}
@@ -187,7 +187,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/verifiableCredentialType'
+                  $ref: '#/components/schemas/verifiableCredential'
         401:
           description: Not Authorized
           content: {}
@@ -376,6 +376,30 @@ components:
         credentialSubject:
           type: object
           properties: {}
+
+    verifiableCredential:
+      type: object
+      properties:
+        context:
+          type: array
+          items:
+            type: string
+        id:
+          type: string
+        type:
+          type: string
+        issuer:
+          type: object
+          properties: {}
+        issuanceDate:
+          type: string
+          format: date-time
+        expirationDate:
+          type: string
+          format: date-time
+        credentialSubject:
+          type: object
+          properties: {}
         proof:
           type: object
           properties: 
@@ -398,6 +422,7 @@ components:
               type: string
             proofValue:
               type: string
+
             
 
       


### PR DESCRIPTION
# Description

This PR adds the `proof` object as a part of the credential schema to add support for returning proofs while fetching credentials.
This PR is in correspondence to the following [issue](https://github.com/Sunbird-RC/community/issues/722)