### PR TITLE
#837-Closing the claim and invalidating the pending attestations when entity is updated

### DIFF
--- a/java/claim/src/main/java/dev/sunbirdrc/claim/repository/ClaimRepository.java
+++ b/java/claim/src/main/java/dev/sunbirdrc/claim/repository/ClaimRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ClaimRepository extends JpaRepository<Claim, String> {
     List<Claim> findByConditionsIn(List<String> conditions);
     List<Claim> findByAttestorEntityIn(List<String> entities);
     List<Claim> findByAttestorEntity(String entity);
+    List<Claim> findByAttestationIdEquals(String attestationId);
 }

--- a/java/claim/src/main/java/dev/sunbirdrc/claim/service/ClaimService.java
+++ b/java/claim/src/main/java/dev/sunbirdrc/claim/service/ClaimService.java
@@ -53,6 +53,10 @@ public class ClaimService {
         return claimRepository.findAll();
     }
 
+    public List<Claim> findByAttestationId(String attestationId) {
+        return claimRepository.findByAttestationIdEquals(attestationId);
+    }
+
     public Map<String, Object> findClaimsForAttestor(String entity, JsonNode attestorNode, Pageable pageable) {
         List<Claim> claims = claimRepository.findByAttestorEntity(entity);
         logger.info("Found {} claims to process", claims.size());
@@ -97,6 +101,16 @@ public class ClaimService {
         claim.setStatus(ClaimStatus.CLOSED.name());
         claim.setAttestorUserId(requestBody.get(USER_ID).asText());
         return claimRepository.save(claim);
+    }
+
+    public Claim closeClaim(Claim claim, String notes, String userId) {
+        claim.setUpdatedAt(new Date());
+        claim.setStatus(ClaimStatus.CLOSED.name());
+        Claim updatedClaim = claimRepository.save(claim);
+        if (notes != null) {
+            addNotes(notes, updatedClaim, userId);
+        }
+        return updatedClaim;
     }
 
     public void addNotes(String notes, Claim claim, String addedBy) {

--- a/java/claim/src/main/java/dev/sunbirdrc/claim/service/ClaimsAuthorizer.java
+++ b/java/claim/src/main/java/dev/sunbirdrc/claim/service/ClaimsAuthorizer.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.Collections;
+import java.util.Objects;
 
 @Service
 public class ClaimsAuthorizer {
@@ -47,5 +48,9 @@ public class ClaimsAuthorizer {
             return claim.getEntityId().equals(userEntityId);
         }
         return false;
+    }
+
+    public boolean isAuthorizedToCloseClaim(Claim claim, String userId) {
+        return Objects.equals(claim.getEntityId(), userId);
     }
 }

--- a/java/registry/src/main/java/dev/sunbirdrc/registry/util/ClaimRequestClient.java
+++ b/java/registry/src/main/java/dev/sunbirdrc/registry/util/ClaimRequestClient.java
@@ -53,11 +53,27 @@ public class ClaimRequestClient {
         return restTemplate.postForObject(claimRequestUrl + FETCH_CLAIMS_PATH + "/" + claimId, requestBody, JsonNode.class);
     }
 
+    public JsonNode getClaimByAttestationId(String attestationId) {
+        return restTemplate.getForObject(claimRequestUrl + FETCH_CLAIMS_PATH + "?attestationId=" + attestationId, JsonNode.class);
+    }
+
     public ResponseEntity<Object> attestClaim(JsonNode attestationRequest, String claimId) {
         return restTemplate.exchange(
                 claimRequestUrl + CLAIMS_PATH + "/" + claimId,
                 HttpMethod.POST,
                 new HttpEntity<>(attestationRequest),
+                Object.class
+        );
+    }
+
+    public ResponseEntity<Object> closeClaim(String claimId, String userId, String notes) {
+        ObjectNode requestBody = JsonNodeFactory.instance.objectNode();
+        requestBody.set("userId", JsonNodeFactory.instance.textNode(userId));
+        requestBody.set("notes", JsonNodeFactory.instance.textNode(notes));
+        return restTemplate.exchange(
+                claimRequestUrl + CLAIMS_PATH + "/" + claimId,
+                HttpMethod.PUT,
+                new HttpEntity<>(requestBody),
                 Object.class
         );
     }


### PR DESCRIPTION
Ticket details are [here](https://github.com/orgs/Sunbird-RC/projects/16/views/26?filterQuery=sprint%3A%40previous%2C%40current%2C%40next+assignee%3A%22shiva-beehyv%22&pane=issue&itemId=40563845)

When an entity is updated, the attestations that are in pending state are to be closed

Initial approach to fix this was to invoke the ClaimPluginActor to reject the claim and let the existing flow take care of closing the claim and the attestation. But this didn't work since only the attestor is allowed to make the changes in this flow.
So added new apis to close claims.