### PR TITLE
Replaces ghrc.io with ghcr.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ node {
                 app.push("${env.BUILD_NUMBER}")
                 app.push("latest")
            }
-           docker.withRegistry('ghrc.io', 'sunbird-rc') {
+           docker.withRegistry('ghcr.io', 'sunbird-rc') {
                claimApp.push("${env.BUILD_NUMBER}")
                claimApp.push("latest")
           }


### PR DESCRIPTION
This PR replaces `ghrc.io` with the official `ghcr.io`. This domain is a known malicious typo-squatter.

More details here: https://bmitch.net/blog/2025-08-22-ghrc-appears-malicious/