### PR TITLE
feat: add PEX support for OID4VP presentations

### DIFF
--- a/services/credentials-service/package-lock.json
+++ b/services/credentials-service/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@digitalbazaar/credentials-context": "^3.2.0",
         "@digitalbazaar/ed25519-signature-2018": "^4.0.0",
         "@digitalbazaar/ed25519-signature-2020": "^5.2.0",
         "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
         "@digitalbazaar/ed25519-verification-key-2020": "^4.1.0",
-        "@digitalbazaar/vc": "^6.3.0",
+        "@digitalbazaar/vc": "^7.1.1",
         "@fastify/helmet": "8.0.0",
         "@fastify/static": "^7.0.4",
         "@fastify/view": "^9.1.0",
@@ -312,6 +313,16 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.7.tgz",
@@ -343,6 +354,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -902,6 +923,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@digitalbazaar/credentials-context": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/credentials-context/-/credentials-context-3.2.0.tgz",
+      "integrity": "sha512-WruXZAF182pCYq/z2JPJ4N4mVDu6pd/hr7widdCqbKekA53BXHoX7XhL9tmRmQ8kfmkaStBfla67QHhkchWYBQ==",
+      "license": "SEE LICENSE IN LICENSE.md"
+    },
     "node_modules/@digitalbazaar/ed25519-multikey": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@digitalbazaar/ed25519-multikey/-/ed25519-multikey-1.1.0.tgz",
@@ -1089,31 +1116,96 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@digitalbazaar/vc": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@digitalbazaar/vc/-/vc-6.3.0.tgz",
-      "integrity": "sha512-zgrV387lEek2NUoji8jNYRGJhlrWZnZRLfvfVdCd2/ONjcDa3eV8sM5H7s1hnTGJl8DB7ArtrhNiirxEllD0Fw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/vc/-/vc-7.3.0.tgz",
+      "integrity": "sha512-liPd4fCQYGXB3aTUY7XNt2A41EGwwdCJdqQvOjXp1ySwLptvifOYA/EvlViJfFgjDeU5DaSEeB+2V1/BY6oMHA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "credentials-context": "^2.0.0",
-        "jsonld": "^8.3.1",
-        "jsonld-signatures": "^11.2.1"
+        "@digitalbazaar/credentials-context": "^3.2.0",
+        "jsonld": "^9.0.0",
+        "jsonld-signatures": "^11.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/@digitalbazaar/http-client": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.4.0.tgz",
+      "integrity": "sha512-ODhCGmElUPmR3IR+KZmBNkRAFyjJ01rxvk2E+/qQ2h2EGPJH5k6bz3N24ympGc5+i4YCGk/ipIpmkwc0+iSmRg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.3",
+        "undici": "^6.28.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@digitalbazaar/vc/node_modules/jsonld-signatures": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.2.1.tgz",
-      "integrity": "sha512-RNaHTEeRrX0jWeidPCwxMq/E/Ze94zFyEZz/v267ObbCHQlXhPO7GtkY6N5PSHQfQhZPXa8NlMBg5LiDF4dNbA==",
+      "version": "11.6.0",
+      "resolved": "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz",
+      "integrity": "sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@digitalbazaar/security-context": "^1.0.0",
-        "jsonld": "^8.0.0",
+        "jsonld": "^9.0.0",
+        "rdf-canonize": "^5.0.0",
         "serialize-error": "^8.1.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@digitalbazaar/vc/node_modules/serialize-error": {
@@ -1130,6 +1222,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@digitalbazaar/vc/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3949,6 +4056,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/babel-plugin-jest-hoist": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
@@ -4395,10 +4512,13 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/canonicalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz",
-      "integrity": "sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==",
-      "license": "Apache-2.0"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -4816,12 +4936,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/credentials-context": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/credentials-context/-/credentials-context-2.0.0.tgz",
-      "integrity": "sha512-/mFKax6FK26KjgV2KW2D4YqKgoJ5DVJpNt87X2Jc9IxT2HBMy7nEIlc+n7pEi+YFFe721XqrvZPd+jbyyBjsvQ==",
-      "license": "SEE LICENSE IN LICENSE.md"
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4864,6 +4978,15 @@
       },
       "engines": {
         "node": ">=8.3.0"
+      }
+    },
+    "node_modules/crypto-ld/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/dashdash": {
@@ -8581,6 +8704,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonld-signatures/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/jsonld/node_modules/canonicalize": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
@@ -8994,6 +9126,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/make-error": {
@@ -10552,6 +10693,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
       }
     },
     "node_modules/request/node_modules/qs": {

--- a/services/credentials-service/package.json
+++ b/services/credentials-service/package.json
@@ -23,11 +23,11 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
+    "@digitalbazaar/credentials-context": "^3.2.0",
     "@digitalbazaar/ed25519-signature-2018": "^4.0.0",
     "@digitalbazaar/ed25519-signature-2020": "^5.2.0",
     "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^4.1.0",
-    "@digitalbazaar/credentials-context": "^3.2.0",
     "@digitalbazaar/vc": "^7.1.1",
     "@fastify/helmet": "8.0.0",
     "@fastify/static": "^7.0.4",

--- a/services/credentials-service/package.json
+++ b/services/credentials-service/package.json
@@ -23,11 +23,11 @@
     "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
-    "@digitalbazaar/credentials-context": "^3.2.0",
     "@digitalbazaar/ed25519-signature-2018": "^4.0.0",
     "@digitalbazaar/ed25519-signature-2020": "^5.2.0",
     "@digitalbazaar/ed25519-verification-key-2018": "^4.0.0",
     "@digitalbazaar/ed25519-verification-key-2020": "^4.1.0",
+    "@digitalbazaar/credentials-context": "^3.2.0",
     "@digitalbazaar/vc": "^7.1.1",
     "@fastify/helmet": "8.0.0",
     "@fastify/static": "^7.0.4",

--- a/services/credentials-service/src/credentials/credentials.service.ts
+++ b/services/credentials-service/src/credentials/credentials.service.ts
@@ -27,6 +27,8 @@ import {
  } from 'vc.types';
 import { SignResult } from './utils/credential-format.service';
 import { RevocationListDTO } from './dto/revocaiton-list.dto';
+import { resolveSelfContainedDidToJwk } from './utils/self-contained-did.util';
+import { verifyJsonWebSignature2020 } from './utils/jws2020.util';
 
 @Injectable()
 export class CredentialsService {
@@ -165,6 +167,11 @@ export class CredentialsService {
     if (typeof credToVerify === 'string') {
       return this.verifyEnvelopedCredential(credToVerify, status, options);
     }
+
+    const types = [].concat((credToVerify as any)?.type || []);
+    if (types.includes('VerifiablePresentation')) {
+      return this.verifyPresentation(credToVerify, options);
+    }
     try {
       // calling identity service to verify the issuer DID
       const issuerId = (credToVerify.issuer?.id || credToVerify.issuer) as string;
@@ -296,6 +303,67 @@ export class CredentialsService {
       };
     } catch (e) {
       this.logger.error('Error verifying enveloped credential: ', e);
+      return { errors: [e] };
+    }
+  }
+
+  // Verifies a full VerifiablePresentation's own holder-binding proof —
+  // JsonWebSignature2020, `authentication` purpose, challenge/domain bound
+  // to this specific presentation request — NOT any embedded VC's
+  // assertion proof (callers verify those separately, per-VC, via the path
+  // above; a VP has no `issuer`/`expirationDate` of its own to check).
+  //
+  // No suite already registered in getSuite() (Ed25519Signature2020/2018,
+  // RsaSignature2018) covers JsonWebSignature2020 — see jws2020.util.ts.
+  // The holder DID is routinely did:jwk for real wallets (confirmed live
+  // against Inji Wallet), resolved locally (self-contained, no registry
+  // lookup); falls back to identity-service's resolveDID for other methods
+  // (e.g. did:web) the same way the bare-VC path above does.
+  private async verifyPresentation(
+    vp: any,
+    options?: { challenge?: string; domain?: string },
+  ) {
+    try {
+      const proof = vp?.proof || {};
+      if (proof.type !== 'JsonWebSignature2020') {
+        throw new Error(`unsupported VP proof type '${proof.type}'`);
+      }
+      const verificationMethodId: string | undefined =
+        typeof proof.verificationMethod === 'string' ? proof.verificationMethod : proof.verificationMethod?.id;
+      const holderDid = verificationMethodId?.split('#')[0];
+
+      let publicKeyJwk = resolveSelfContainedDidToJwk(holderDid);
+      let did: DIDDocument | undefined;
+      if (!publicKeyJwk) {
+        did = await this.identityUtilsService.resolveDID(holderDid);
+        const vm = did.verificationMethod?.find(
+          (d) => d.id === verificationMethodId,
+        );
+        publicKeyJwk = (vm as any)?.publicKeyJwk;
+        if (!publicKeyJwk) throw new Error('holder public key not resolvable');
+      }
+      // getDocumentLoader's didDoc-self-reference branch (`url === didDoc?.id`)
+      // simply never matches when did is undefined (the did:jwk case).
+      const documentLoader = this.getDocumentLoader(did);
+
+      const jwsResult = await verifyJsonWebSignature2020(vp, publicKeyJwk, 'authentication', documentLoader);
+      if (!jwsResult.verified) {
+        this.logger.error('Error in verifying presentation: ', jwsResult.error);
+      }
+
+      const replay = this.checkChallengeDomain(proof, options);
+      const proofOk = jwsResult.verified && replay.ok;
+
+      return {
+        checks: [
+          {
+            proof: proofOk ? 'OK' : 'NOK',
+            ...(replay.checked && { replay: replay.ok ? 'OK' : 'NOK' }),
+          },
+        ],
+      };
+    } catch (e) {
+      this.logger.error('Error in verifying presentation: ', e);
       return { errors: [e] };
     }
   }

--- a/services/credentials-service/src/credentials/documents.ts
+++ b/services/credentials-service/src/credentials/documents.ts
@@ -784,6 +784,88 @@ export const DOCUMENTS = {
             }
         }
     },
+    "https://w3id.org/security/suites/jws-2020/v1": {
+        "@context": {
+            "privateKeyJwk": {
+                "@id": "https://w3id.org/security#privateKeyJwk",
+                "@type": "@json"
+            },
+            "JsonWebKey2020": {
+                "@id": "https://w3id.org/security#JsonWebKey2020",
+                "@context": {
+                    "@protected": true,
+                    "id": "@id",
+                    "type": "@type",
+                    "publicKeyJwk": {
+                        "@id": "https://w3id.org/security#publicKeyJwk",
+                        "@type": "@json"
+                    }
+                }
+            },
+            "JsonWebSignature2020": {
+                "@id": "https://w3id.org/security#JsonWebSignature2020",
+                "@context": {
+                    "@protected": true,
+
+                    "id": "@id",
+                    "type": "@type",
+
+                    "challenge": "https://w3id.org/security#challenge",
+                    "created": {
+                        "@id": "http://purl.org/dc/terms/created",
+                        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                    },
+                    "domain": "https://w3id.org/security#domain",
+                    "expires": {
+                        "@id": "https://w3id.org/security#expiration",
+                        "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+                    },
+                    "jws": "https://w3id.org/security#jws",
+                    "nonce": "https://w3id.org/security#nonce",
+                    "proofPurpose": {
+                        "@id": "https://w3id.org/security#proofPurpose",
+                        "@type": "@vocab",
+                        "@context": {
+                            "@protected": true,
+
+                            "id": "@id",
+                            "type": "@type",
+
+                            "assertionMethod": {
+                                "@id": "https://w3id.org/security#assertionMethod",
+                                "@type": "@id",
+                                "@container": "@set"
+                            },
+                            "authentication": {
+                                "@id": "https://w3id.org/security#authenticationMethod",
+                                "@type": "@id",
+                                "@container": "@set"
+                            },
+                            "capabilityInvocation": {
+                                "@id": "https://w3id.org/security#capabilityInvocationMethod",
+                                "@type": "@id",
+                                "@container": "@set"
+                            },
+                            "capabilityDelegation": {
+                                "@id": "https://w3id.org/security#capabilityDelegationMethod",
+                                "@type": "@id",
+                                "@container": "@set"
+                            },
+                            "keyAgreement": {
+                                "@id": "https://w3id.org/security#keyAgreementMethod",
+                                "@type": "@id",
+                                "@container": "@set"
+                            }
+                        }
+                    },
+                    "verificationMethod": {
+                        "@id": "https://w3id.org/security#verificationMethod",
+                        "@type": "@id"
+                    }
+                }
+            }
+        }
+    },
     "https://w3id.org/security/suites/ed25519-2018/v1": {
         "@context": {
           "id": "@id",

--- a/services/credentials-service/src/credentials/dto/verify-credential.dto.ts
+++ b/services/credentials-service/src/credentials/dto/verify-credential.dto.ts
@@ -1,7 +1,7 @@
 import { IssuedVerifiableCredential } from '../schema/VC.schema';
 
 export class VerifyCredentialDTO {
-  verifiableCredential: IssuedVerifiableCredential;
+  verifiableCredential: IssuedVerifiableCredential | Record<string, any>;
   options: {
     challenge: string;
     domain: string;

--- a/services/credentials-service/src/credentials/utils/jws2020.util.spec.ts
+++ b/services/credentials-service/src/credentials/utils/jws2020.util.spec.ts
@@ -1,0 +1,155 @@
+import * as crypto from 'crypto';
+import * as jsonld from 'jsonld';
+import { verifyJsonWebSignature2020 } from './jws2020.util';
+
+// Fully offline (no network context fetch): a tiny inline @context covering
+// only the terms this test's documents actually use, so canonicalization
+// never needs to fetch anything.
+const CONTEXT = {
+  '@context': {
+    '@vocab': 'https://example.test/vocab#',
+    id: '@id',
+    type: '@type',
+    JsonWebSignature2020: 'https://w3id.org/security#JsonWebSignature2020',
+    proof: { '@id': 'https://w3id.org/security#proof', '@type': '@id', '@container': '@graph' },
+    challenge: 'https://w3id.org/security#challenge',
+    domain: 'https://w3id.org/security#domain',
+    proofPurpose: { '@id': 'https://w3id.org/security#proofPurpose', '@type': '@vocab' },
+    verificationMethod: { '@id': 'https://w3id.org/security#verificationMethod', '@type': '@id' },
+    created: { '@id': 'http://purl.org/dc/terms/created', '@type': 'http://www.w3.org/2001/XMLSchema#dateTime' },
+  },
+};
+const CONTEXT_URL = 'https://example.test/context';
+
+async function documentLoader(url: string) {
+  if (url === CONTEXT_URL) return { contextUrl: null, documentUrl: url, document: CONTEXT };
+  throw new Error(`unexpected context fetch: ${url}`);
+}
+
+// Test-only signer implementing the exact same "Create Verify Hash"
+// algorithm the util verifies against — this is a self-consistency check
+// (proves sign/verify agree and tampering is rejected), NOT proof that a
+// real wallet's actual JsonWebSignature2020 output verifies; that needs a
+// live test against the real wallet.
+async function signJws2020(document: any, privateKey: crypto.KeyObject, alg: string): Promise<string> {
+  const header = { alg, b64: false, crit: ['b64'] };
+  const headerB64 = Buffer.from(JSON.stringify(header)).toString('base64url');
+
+  const { jws: _jws, ...proofOptions } = document.proof;
+  if (!proofOptions['@context']) proofOptions['@context'] = document['@context'];
+  const { proof: _proof, ...docWithoutProof } = document;
+
+  const [optionsCanon, docCanon] = await Promise.all([
+    jsonld.canonize(proofOptions, { algorithm: 'URDNA2015', documentLoader } as any),
+    jsonld.canonize(docWithoutProof, { algorithm: 'URDNA2015', documentLoader } as any),
+  ]);
+  const optionsHash = crypto.createHash('sha256').update(optionsCanon, 'utf8').digest();
+  const docHash = crypto.createHash('sha256').update(docCanon, 'utf8').digest();
+  const verifyData = Buffer.concat([optionsHash, docHash]);
+  const signingInput = Buffer.concat([Buffer.from(headerB64, 'ascii'), Buffer.from('.'), verifyData]);
+
+  let signature: Buffer;
+  if (alg === 'EdDSA') {
+    signature = crypto.sign(null, signingInput, privateKey);
+  } else {
+    signature = crypto.sign('sha256', signingInput, { key: privateKey, dsaEncoding: 'ieee-p1363' });
+  }
+  return `${headerB64}..${signature.toString('base64url')}`;
+}
+
+function buildVp(proofExtra: Record<string, any>): any {
+  return {
+    '@context': CONTEXT_URL,
+    type: 'VerifiablePresentation',
+    id: 'urn:uuid:test',
+    holder: 'did:jwk:test',
+    proof: {
+      type: 'JsonWebSignature2020',
+      created: '2026-01-01T00:00:00Z',
+      proofPurpose: 'authentication',
+      verificationMethod: 'did:jwk:test#0',
+      jws: undefined as string | undefined,
+      ...proofExtra,
+    },
+  };
+}
+
+describe('verifyJsonWebSignature2020', () => {
+  it('verifies a correctly-signed ES256 (P-256) proof', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const publicJwk = publicKey.export({ format: 'jwk' }) as any;
+
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = await signJws2020(vp, privateKey, 'ES256');
+
+    const res = await verifyJsonWebSignature2020(vp, publicJwk, 'authentication', documentLoader);
+    expect(res).toEqual({ verified: true });
+  });
+
+  it('verifies a correctly-signed EdDSA (Ed25519) proof', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const publicJwk = publicKey.export({ format: 'jwk' }) as any;
+
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = await signJws2020(vp, privateKey, 'EdDSA');
+
+    const res = await verifyJsonWebSignature2020(vp, publicJwk, 'authentication', documentLoader);
+    expect(res).toEqual({ verified: true });
+  });
+
+  it('rejects a tampered document (signature no longer matches)', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const publicJwk = publicKey.export({ format: 'jwk' }) as any;
+
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = await signJws2020(vp, privateKey, 'ES256');
+    (vp as any).holder = 'did:jwk:attacker-substituted';
+
+    const res = await verifyJsonWebSignature2020(vp, publicJwk, 'authentication', documentLoader);
+    expect(res.verified).toBe(false);
+  });
+
+  it('rejects when proofPurpose does not match what the caller expects', async () => {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const publicJwk = publicKey.export({ format: 'jwk' }) as any;
+
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = await signJws2020(vp, privateKey, 'ES256');
+
+    const res = await verifyJsonWebSignature2020(vp, publicJwk, 'assertionMethod', documentLoader);
+    expect(res).toEqual({
+      verified: false,
+      error: "expected proofPurpose 'assertionMethod', got 'authentication'",
+    });
+  });
+
+  it('rejects a non-detached (embedded payload) JWS', async () => {
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = 'header.payload.signature';
+    const { publicKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const res = await verifyJsonWebSignature2020(
+      vp,
+      publicKey.export({ format: 'jwk' }) as any,
+      'authentication',
+      documentLoader,
+    );
+    expect(res.verified).toBe(false);
+    expect(res.error).toMatch(/detached JWS/);
+  });
+
+  it('rejects a signature from the wrong key', async () => {
+    const { privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+    const { publicKey: wrongPublicKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+
+    const vp = buildVp({ challenge: 'n1', domain: 'https://verifier.example/vp/response' });
+    vp.proof.jws = await signJws2020(vp, privateKey, 'ES256');
+
+    const res = await verifyJsonWebSignature2020(
+      vp,
+      wrongPublicKey.export({ format: 'jwk' }) as any,
+      'authentication',
+      documentLoader,
+    );
+    expect(res.verified).toBe(false);
+  });
+});

--- a/services/credentials-service/src/credentials/utils/jws2020.util.ts
+++ b/services/credentials-service/src/credentials/utils/jws2020.util.ts
@@ -1,0 +1,127 @@
+import * as crypto from 'crypto';
+import * as jsonld from 'jsonld';
+
+export interface Jws2020VerifyResult {
+  verified: boolean;
+  error?: string;
+}
+
+const HASH_BY_ALG: Record<string, string> = {
+  ES256: 'sha256',
+  ES384: 'sha384',
+  ES512: 'sha512',
+  RS256: 'sha256',
+  RS384: 'sha384',
+  RS512: 'sha512',
+  PS256: 'sha256',
+  PS384: 'sha384',
+  PS512: 'sha512',
+};
+
+// Verifies a JsonWebSignature2020 Linked-Data proof per
+// https://w3c-ccg.github.io/lds-jws2020/: canonicalize the proof options and
+// the document-minus-proof separately (URDNA2015), SHA-256 hash each,
+// concatenate the two hashes, and check that against a detached JWS
+// (RFC7797 b64:false — header..signature, no embedded payload) carried in
+// `proof.jws`. `publicKeyJwk` is imported via Node's `crypto` module, which
+// also does the actual signature check — including converting JWS's raw
+// r||s ECDSA encoding via `dsaEncoding: 'ieee-p1363'` for the ES* algorithms.
+export async function verifyJsonWebSignature2020(
+  document: any,
+  publicKeyJwk: crypto.JsonWebKey,
+  expectedPurpose: string,
+  documentLoader?: (url: string) => Promise<any>,
+): Promise<Jws2020VerifyResult> {
+  const proof = document?.proof;
+  if (!proof || proof.type !== 'JsonWebSignature2020') {
+    return { verified: false, error: 'not a JsonWebSignature2020 proof' };
+  }
+  if (proof.proofPurpose !== expectedPurpose) {
+    return {
+      verified: false,
+      error: `expected proofPurpose '${expectedPurpose}', got '${proof.proofPurpose}'`,
+    };
+  }
+  if (typeof proof.jws !== 'string') {
+    return { verified: false, error: 'proof.jws missing' };
+  }
+
+  const jwsParts = proof.jws.split('.');
+  // RFC7797 detached mode: header..signature — the empty middle segment IS
+  // the point; the payload is supplied out-of-band (the hashes below).
+  if (jwsParts.length !== 3 || jwsParts[1] !== '') {
+    return { verified: false, error: 'proof.jws is not a detached JWS (expected header..signature)' };
+  }
+  const [headerB64, , signatureB64] = jwsParts;
+
+  let header: { alg?: string; b64?: boolean; crit?: string[] };
+  try {
+    header = JSON.parse(Buffer.from(headerB64, 'base64url').toString('utf8'));
+  } catch {
+    return { verified: false, error: 'malformed JWS protected header' };
+  }
+  if (header.b64 !== false || !header.crit?.includes('b64')) {
+    return { verified: false, error: "JWS header must set b64:false and crit:['b64'] (detached payload)" };
+  }
+  const alg = header.alg;
+  if (!alg) return { verified: false, error: 'JWS header missing alg' };
+
+  // "Create Verify Hash" algorithm (Linked Data Proofs 1.0 / LD-JWS suite):
+  // hash the canonicalized proof-options (proof minus jws, @context defaulted
+  // to the document's) and the canonicalized document-minus-proof, and
+  // concatenate — that concatenation is the JWS's detached payload.
+  const { jws: _jws, ...proofOptions } = proof;
+  if (!proofOptions['@context']) proofOptions['@context'] = document['@context'];
+  const { proof: _proof, ...docWithoutProof } = document;
+
+  let optionsCanon: string;
+  let docCanon: string;
+  try {
+    [optionsCanon, docCanon] = await Promise.all([
+      jsonld.canonize(proofOptions, { algorithm: 'URDNA2015', documentLoader } as any),
+      jsonld.canonize(docWithoutProof, { algorithm: 'URDNA2015', documentLoader } as any),
+    ]);
+  } catch (e) {
+    return { verified: false, error: `canonicalization failed: ${e}` };
+  }
+
+  const optionsHash = crypto.createHash('sha256').update(optionsCanon, 'utf8').digest();
+  const docHash = crypto.createHash('sha256').update(docCanon, 'utf8').digest();
+  const verifyData = Buffer.concat([optionsHash, docHash]);
+  const signingInput = Buffer.concat([Buffer.from(headerB64, 'ascii'), Buffer.from('.'), verifyData]);
+  const signature = Buffer.from(signatureB64, 'base64url');
+
+  let publicKey: crypto.KeyObject;
+  try {
+    publicKey = crypto.createPublicKey({ key: publicKeyJwk as any, format: 'jwk' });
+  } catch (e) {
+    return { verified: false, error: `invalid public key JWK: ${e}` };
+  }
+
+  try {
+    const verified = verifySignature(alg, signingInput, signature, publicKey);
+    return verified ? { verified: true } : { verified: false, error: 'signature verification failed' };
+  } catch (e) {
+    return { verified: false, error: `signature verification error: ${e}` };
+  }
+}
+
+function verifySignature(alg: string, data: Buffer, signature: Buffer, key: crypto.KeyObject): boolean {
+  if (alg === 'EdDSA') {
+    return crypto.verify(null, data, key, signature);
+  }
+  const hash = HASH_BY_ALG[alg];
+  if (!hash) throw new Error(`unsupported alg '${alg}'`);
+  if (alg.startsWith('PS')) {
+    return crypto.verify(hash, data, { key, padding: crypto.constants.RSA_PKCS1_PSS_PADDING }, signature);
+  }
+  if (alg.startsWith('RS')) {
+    return crypto.verify(hash, data, key, signature);
+  }
+  if (alg.startsWith('ES')) {
+    // JWS ECDSA signatures are raw fixed-length r||s (RFC7518 §3.4), not the
+    // ASN.1 DER encoding Node's crypto.verify expects by default.
+    return crypto.verify(hash, data, { key, dsaEncoding: 'ieee-p1363' }, signature);
+  }
+  throw new Error(`unsupported alg '${alg}'`);
+}

--- a/services/credentials-service/src/credentials/utils/self-contained-did.util.ts
+++ b/services/credentials-service/src/credentials/utils/self-contained-did.util.ts
@@ -1,0 +1,23 @@
+import * as crypto from 'crypto';
+
+// `did:jwk` identifiers are self-contained: the public key JWK is the
+// base64url payload of the identifier itself, so resolving one is local
+// decoding, not a network lookup.
+//
+// ponytail: did:jwk only — did:key (multicodec/multibase) decoding lives in
+// oid4vc-service's version of this file; port it here too if needed.
+
+export function isSelfContainedDid(did?: string): boolean {
+  return !!did && did.startsWith('did:jwk:');
+}
+
+export function resolveSelfContainedDidToJwk(did?: string): crypto.JsonWebKey | undefined {
+  if (!did || !did.startsWith('did:jwk:')) return undefined;
+  try {
+    return JSON.parse(
+      Buffer.from(did.slice('did:jwk:'.length).split('#')[0], 'base64url').toString('utf8'),
+    );
+  } catch {
+    throw new Error('malformed did:jwk');
+  }
+}

--- a/services/credentials-service/yarn.lock
+++ b/services/credentials-service/yarn.lock
@@ -365,7 +365,7 @@
 
 "@digitalbazaar/credentials-context@^3.2.0":
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@digitalbazaar/credentials-context/-/credentials-context-3.2.0.tgz#c5efa74744c25be8d3a7d26b1d4d2fd349b19ae8"
+  resolved "https://registry.npmjs.org/@digitalbazaar/credentials-context/-/credentials-context-3.2.0.tgz"
   integrity sha512-WruXZAF182pCYq/z2JPJ4N4mVDu6pd/hr7widdCqbKekA53BXHoX7XhL9tmRmQ8kfmkaStBfla67QHhkchWYBQ==
 
 "@digitalbazaar/ed25519-multikey@^1.1.0":
@@ -430,12 +430,12 @@
     undici "^5.21.2"
 
 "@digitalbazaar/http-client@^4.2.0":
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/@digitalbazaar/http-client/-/http-client-4.3.0.tgz#c76e738c8c8402d3bd11891932219a5163efd8c3"
-  integrity sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.4.0.tgz"
+  integrity sha512-ODhCGmElUPmR3IR+KZmBNkRAFyjJ01rxvk2E+/qQ2h2EGPJH5k6bz3N24ympGc5+i4YCGk/ipIpmkwc0+iSmRg==
   dependencies:
-    ky "^1.14.2"
-    undici "^6.23.0"
+    ky "^1.14.3"
+    undici "^6.28.0"
 
 "@digitalbazaar/jws-linked-data-signature@^3.0.0":
   version "3.0.0"
@@ -452,7 +452,7 @@
 
 "@digitalbazaar/vc@^7.1.1":
   version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@digitalbazaar/vc/-/vc-7.3.0.tgz#ca876cf27c1f54837266a0764a1d45188a6af2fd"
+  resolved "https://registry.npmjs.org/@digitalbazaar/vc/-/vc-7.3.0.tgz"
   integrity sha512-liPd4fCQYGXB3aTUY7XNt2A41EGwwdCJdqQvOjXp1ySwLptvifOYA/EvlViJfFgjDeU5DaSEeB+2V1/BY6oMHA==
   dependencies:
     "@digitalbazaar/credentials-context" "^3.2.0"
@@ -872,14 +872,6 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
 
-"@jridgewell/trace-mapping@0.3.9":
-  version "0.3.9"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
-  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-
 "@jridgewell/trace-mapping@^0.3.12", "@jridgewell/trace-mapping@^0.3.18", "@jridgewell/trace-mapping@^0.3.20", "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz"
@@ -887,6 +879,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@lukeed/csprng@^1.0.0":
   version "1.1.0"
@@ -952,9 +952,9 @@
   resolved "https://registry.npmjs.org/@nestjs/common/-/common-9.4.3.tgz"
   integrity sha512-Gd6D4IaYj01o14Bwv81ukidn4w3bPHCblMUq+SmUmWLyosK+XQmInCS09SbDDZyL8jy86PngtBLTdhJ2bXSUig==
   dependencies:
-    uid "2.0.2"
     iterare "1.2.1"
     tslib "2.5.3"
+    uid "2.0.2"
 
 "@nestjs/config@^2.2.0":
   version "2.3.4"
@@ -971,12 +971,12 @@
   resolved "https://registry.npmjs.org/@nestjs/core/-/core-9.4.3.tgz"
   integrity sha512-Qi63+wi55Jh4sDyaj5Hhx2jOpKqT386aeo+VOKsxnd+Ql9VvkO/FjmuwBGUyzkJt29ENYc+P0Sx/k5LtstNpPQ==
   dependencies:
-    uid "2.0.2"
     "@nuxtjs/opencollective" "0.3.2"
     fast-safe-stringify "2.1.1"
     iterare "1.2.1"
     path-to-regexp "3.2.0"
     tslib "2.5.3"
+    uid "2.0.2"
 
 "@nestjs/mapped-types@1.2.2":
   version "1.2.2"
@@ -1065,7 +1065,7 @@
   resolved "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz"
   integrity sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==
 
-"@noble/hashes@1.4.0", "@noble/hashes@^1.3.0":
+"@noble/hashes@^1.3.0", "@noble/hashes@1.4.0":
   version "1.4.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz"
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
@@ -1078,7 +1078,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -1501,7 +1501,7 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.11.5":
+"@webassemblyjs/ast@^1.11.5", "@webassemblyjs/ast@1.12.1":
   version "1.12.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz"
   integrity sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==
@@ -1602,7 +1602,7 @@
     "@webassemblyjs/wasm-gen" "1.12.1"
     "@webassemblyjs/wasm-parser" "1.12.1"
 
-"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.11.5":
+"@webassemblyjs/wasm-parser@^1.11.5", "@webassemblyjs/wasm-parser@1.12.1":
   version "1.12.1"
   resolved "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz"
   integrity sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==
@@ -1674,7 +1674,7 @@ acorn@^8.11.0, acorn@^8.4.1, acorn@^8.7.1, acorn@^8.8.2, acorn@^8.9.0:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz"
   integrity sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==
 
-ajv-formats@2.1.1, ajv-formats@^2.1.1:
+ajv-formats@^2.1.1, ajv-formats@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz"
   integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
@@ -1693,17 +1693,27 @@ ajv-keywords@^3.5.2:
   resolved "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
-ajv@8.12.0:
-  version "8.12.0"
-  resolved "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz"
-  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+ajv@^6.12.3:
+  version "6.12.6"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -1722,6 +1732,16 @@ ajv@^8.0.0, ajv@^8.10.0, ajv@^8.11.0, ajv@^8.12.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.4.1"
+
+ajv@8.12.0:
+  version "8.12.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz"
+  integrity sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
 
 ansi-align@^3.0.0:
   version "3.0.1"
@@ -1850,7 +1870,7 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
-assert-plus@1.0.0, assert-plus@^1.0.0:
+assert-plus@^1.0.0, assert-plus@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
@@ -2026,11 +2046,6 @@ bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bn.js@^4.11.9:
-  version "4.12.5"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.5.tgz#74f119ffecd823168d188eae06d97ea40835c489"
-  integrity sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==
-
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz"
@@ -2102,11 +2117,6 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-brorand@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
-  integrity sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==
 
 browserslist@^4.14.5, browserslist@^4.22.2:
   version "4.23.1"
@@ -2196,30 +2206,17 @@ call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.1"
 
-call-bind@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
-  integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    es-define-property "^1.0.1"
-    get-intrinsic "^1.3.0"
-    set-function-length "^1.2.2"
-
-call-bound@^1.0.3, call-bound@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
-  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    get-intrinsic "^1.3.0"
-
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-camelcase@^5.0.0, camelcase@^5.3.1:
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -2239,14 +2236,9 @@ canonicalize@^1.0.1:
   resolved "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz"
   integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
 
-canonicalize@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/canonicalize/-/canonicalize-2.0.0.tgz"
-  integrity sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==
-
-canonicalize@^2.1.0:
+canonicalize@^2.0.0, canonicalize@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.1.0.tgz#92a20ecfb94e96591badf4977dc2fb1bfbc31dc5"
+  resolved "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz"
   integrity sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==
 
 caseless@~0.12.0:
@@ -2259,14 +2251,6 @@ cbor-web@^9.0.2:
   resolved "https://registry.npmjs.org/cbor-web/-/cbor-web-9.0.2.tgz"
   integrity sha512-N6gU2GsJS8RR5gy1d9wQcSPgn9FGJFY7KNvdDRlwHfz6kCxrQr2TDnrjXHmr6TFSl6Fd0FC4zRnityEldjRGvQ==
 
-chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
-  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz"
@@ -2275,6 +2259,14 @@ chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2, chalk@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -2291,7 +2283,7 @@ check-disk-space@3.4.0:
   resolved "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.4.0.tgz"
   integrity sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==
 
-chokidar@3.5.3, chokidar@^3.4.0, chokidar@^3.5.3:
+chokidar@^3.4.0, chokidar@^3.5.3, chokidar@3.5.3:
   version "3.5.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -2315,14 +2307,6 @@ ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
-
-cipher-base@1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.5.tgz#749f80731c7821e9a5fabd51f6998b696f296686"
-  integrity sha512-xq7ICKB4TMHUx7Tz1L9O2SGKOhYMOTR32oir45Bq28/AQTpHogKgHcoYFSdRbMtddl+ozNXfXY9jWcgYKmde0w==
-  dependencies:
-    inherits "^2.0.4"
-    safe-buffer "^5.2.1"
 
 cjs-module-lexer@^1.0.0:
   version "1.3.1"
@@ -2407,27 +2391,22 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
-
 color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.8, combined-stream@~1.0.6:
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -2438,6 +2417,11 @@ commander@^6.2.0:
   version "6.2.1"
   resolved "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz"
   integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
+commander@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 component-emitter@^1.3.0:
   version "1.3.1"
@@ -2474,7 +2458,7 @@ consola@^2.15.0:
   resolved "https://registry.npmjs.org/consola/-/consola-2.15.3.tgz"
   integrity sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==
 
-content-disposition@0.5.4, content-disposition@^0.5.3:
+content-disposition@^0.5.3, content-disposition@0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
   integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
@@ -2496,7 +2480,7 @@ cookie-signature@1.0.6:
   resolved "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
   integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
 
-cookie@0.5.0, cookie@^0.5.0:
+cookie@^0.5.0, cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
@@ -2506,7 +2490,7 @@ cookiejar@^2.1.4:
   resolved "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@~1.0.0, core-util-is@1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
@@ -2557,7 +2541,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-ld@3.9.0, crypto-ld@^3.7.0:
+crypto-ld@^3.7.0, crypto-ld@3.9.0:
   version "3.9.0"
   resolved "https://registry.npmjs.org/crypto-ld/-/crypto-ld-3.9.0.tgz"
   integrity sha512-PFE7V6A2QNnUp6iiPVEZI4p8wsztkEWLbY1BAXVnclm/aw4KGwpJ+1Ds4vQUCJ5BsWxj15fwE5rHQ8AWaWB2nw==
@@ -2613,19 +2597,19 @@ data-view-byte-offset@^1.0.0:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
-debug@2.6.9:
-  version "2.6.9"
-  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.5"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz"
   integrity sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==
   dependencies:
     ms "2.1.2"
+
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -2816,19 +2800,6 @@ electron-to-chromium@^1.4.796:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.803.tgz"
   integrity sha512-61H9mLzGOCLLVsnLiRzCbc63uldP0AniRYPV3hbGVtONA1pI7qSGILdbofR7A8TMbOypDocEAjH/e+9k1QIe3g==
 
-elliptic@6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
-  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
-  dependencies:
-    bn.js "^4.11.9"
-    brorand "^1.1.0"
-    hash.js "^1.0.0"
-    hmac-drbg "^1.0.1"
-    inherits "^2.0.4"
-    minimalistic-assert "^1.0.1"
-    minimalistic-crypto-utils "^1.0.1"
-
 emittery@^0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz"
@@ -3006,7 +2977,7 @@ eslint-plugin-prettier@^4.0.0:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-scope@5.1.1, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1, eslint-scope@5.1.1:
   version "5.1.1"
   resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -3104,7 +3075,12 @@ estraverse@^4.1.1:
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0, estraverse@^5.2.0:
+estraverse@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+estraverse@^5.2.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
@@ -3226,7 +3202,7 @@ external-editor@^3.0.3:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
+extsprintf@^1.2.0, extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
@@ -3262,7 +3238,7 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0, fast-json-stable-stringify@2.x:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -3297,7 +3273,7 @@ fast-redact@^3.1.1:
   resolved "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz"
   integrity sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==
 
-fast-safe-stringify@2.1.1, fast-safe-stringify@^2.1.1:
+fast-safe-stringify@^2.1.1, fast-safe-stringify@2.1.1:
   version "2.1.1"
   resolved "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
@@ -3425,7 +3401,15 @@ find-my-way@^7.6.0:
     fast-querystring "^1.0.0"
     safe-regex2 "^2.0.0"
 
-find-up@^4.0.0, find-up@^4.1.0:
+find-up@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
+
+find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -3467,13 +3451,6 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-for-each@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
-  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
-  dependencies:
-    is-callable "^1.2.7"
-
 foreground-child@^3.1.0:
   version "3.2.1"
   resolved "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz"
@@ -3505,16 +3482,25 @@ fork-ts-checker-webpack-plugin@8.0.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.5, form-data@~2.3.2:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
-  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+form-data@^4.0.0, form-data@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
+  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.4"
-    mime-types "^2.1.35"
+    hasown "^2.0.2"
+    mime-types "^2.1.12"
+
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -3568,7 +3554,7 @@ fs.realpath@^1.0.0:
 
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -3601,7 +3587,7 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4, get-intrinsic@^1.2.6:
   version "1.3.0"
   resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
@@ -3688,7 +3674,43 @@ glob@^10.3.4:
     minipass "^7.1.2"
     path-scurry "^1.11.1"
 
-glob@^7.0.0, glob@^7.1.3, glob@^7.1.4, glob@^7.2.0:
+glob@^7.0.0:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -3757,9 +3779,9 @@ graphemer@^1.4.0:
   resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-handlebars@4.7.9, handlebars@^4.7.9:
+handlebars@^4.7.9:
   version "4.7.9"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz"
   integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
@@ -3821,25 +3843,10 @@ has-tostringtag@^1.0.0, has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
-  integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
-  dependencies:
-    inherits "^2.0.3"
-    minimalistic-assert "^1.0.1"
-
 hasown@^2.0.0, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
-  dependencies:
-    function-bind "^1.1.2"
-
-hasown@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
-  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
   dependencies:
     function-bind "^1.1.2"
 
@@ -3852,15 +3859,6 @@ hexoid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz"
   integrity sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==
-
-hmac-drbg@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
-  dependencies:
-    hash.js "^1.0.3"
-    minimalistic-assert "^1.0.0"
-    minimalistic-crypto-utils "^1.0.1"
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -3897,7 +3895,7 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24:
+iconv-lite@^0.4.24, iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3948,7 +3946,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
+inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@2, inherits@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4169,13 +4167,6 @@ is-typed-array@^1.1.13:
   integrity sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==
   dependencies:
     which-typed-array "^1.1.14"
-
-is-typed-array@^1.1.14:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
-  integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
-  dependencies:
-    which-typed-array "^1.1.16"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -4653,13 +4644,6 @@ js-tokens@^4.0.0:
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
-  dependencies:
-    argparse "^2.0.1"
-
 js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz"
@@ -4667,6 +4651,13 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+js-yaml@^4.1.0, js-yaml@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
+  dependencies:
+    argparse "^2.0.1"
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -4705,9 +4696,9 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0, json-schema@^0.4.0:
+json-schema@0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
+  resolved "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
 
 json-stable-stringify-without-jsonify@^1.0.1:
@@ -4739,6 +4730,34 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonld-signatures@^11.0.0:
+  version "11.2.1"
+  resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.2.1.tgz"
+  integrity sha512-RNaHTEeRrX0jWeidPCwxMq/E/Ze94zFyEZz/v267ObbCHQlXhPO7GtkY6N5PSHQfQhZPXa8NlMBg5LiDF4dNbA==
+  dependencies:
+    "@digitalbazaar/security-context" "^1.0.0"
+    jsonld "^8.0.0"
+    serialize-error "^8.1.0"
+
+jsonld-signatures@^11.1.0:
+  version "11.2.1"
+  resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.2.1.tgz"
+  integrity sha512-RNaHTEeRrX0jWeidPCwxMq/E/Ze94zFyEZz/v267ObbCHQlXhPO7GtkY6N5PSHQfQhZPXa8NlMBg5LiDF4dNbA==
+  dependencies:
+    "@digitalbazaar/security-context" "^1.0.0"
+    jsonld "^8.0.0"
+    serialize-error "^8.1.0"
+
+jsonld-signatures@^11.6.0:
+  version "11.6.0"
+  resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz"
+  integrity sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==
+  dependencies:
+    "@digitalbazaar/security-context" "^1.0.0"
+    jsonld "^9.0.0"
+    rdf-canonize "^5.0.0"
+    serialize-error "^8.1.0"
+
 jsonld-signatures@7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-7.0.0.tgz"
@@ -4750,25 +4769,6 @@ jsonld-signatures@7.0.0:
     node-forge "^0.10.0"
     security-context "^4.0.0"
     serialize-error "^5.0.0"
-
-jsonld-signatures@^11.0.0, jsonld-signatures@^11.1.0:
-  version "11.2.1"
-  resolved "https://registry.npmjs.org/jsonld-signatures/-/jsonld-signatures-11.2.1.tgz"
-  integrity sha512-RNaHTEeRrX0jWeidPCwxMq/E/Ze94zFyEZz/v267ObbCHQlXhPO7GtkY6N5PSHQfQhZPXa8NlMBg5LiDF4dNbA==
-  dependencies:
-    "@digitalbazaar/security-context" "^1.0.0"
-    jsonld "^8.0.0"
-    serialize-error "^8.1.0"
-
-jsonld-signatures@^11.6.0:
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-11.6.0.tgz#052432d765fe51942749458062bc7a336920681f"
-  integrity sha512-hzYNZXnfy4cUFf9aiFBtduUz+cknbfBLWtTKvoqVyP2ECPwqfsfkHWFlhccWfAKV/LJkPLyKZRwC1B4T5LO4ZQ==
-  dependencies:
-    "@digitalbazaar/security-context" "^1.0.0"
-    jsonld "^9.0.0"
-    rdf-canonize "^5.0.0"
-    serialize-error "^8.1.0"
 
 jsonld@^4.0.1:
   version "4.0.1"
@@ -4794,7 +4794,7 @@ jsonld@^8.0.0, jsonld@^8.1.0, jsonld@^8.3.2:
 
 jsonld@^9.0.0:
   version "9.0.0"
-  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-9.0.0.tgz#2b7266a377e1e5e6f49d69a60cef957c2945c3b4"
+  resolved "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz"
   integrity sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==
   dependencies:
     "@digitalbazaar/http-client" "^4.2.0"
@@ -4880,9 +4880,9 @@ ky@^0.33.3:
   resolved "https://registry.npmjs.org/ky/-/ky-0.33.3.tgz"
   integrity sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==
 
-ky@^1.14.2:
+ky@^1.14.3:
   version "1.14.3"
-  resolved "https://registry.yarnpkg.com/ky/-/ky-1.14.3.tgz#d7fcc6ac93d1588accee72cc44dcc6cf84c0bdaa"
+  resolved "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz"
   integrity sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==
 
 leven@^3.1.0:
@@ -4905,7 +4905,7 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-light-my-request@5.9.1, light-my-request@^5.9.1:
+light-my-request@^5.9.1, light-my-request@5.9.1:
   version "5.9.1"
   resolved "https://registry.npmjs.org/light-my-request/-/light-my-request-5.9.1.tgz"
   integrity sha512-UT7pUk8jNCR1wR7w3iWfIjx32DiB2f3hFdQSOwy3/EPQ3n3VocyipUxcyRZR0ahoev+fky69uA+GejPa9KuHKg==
@@ -4983,7 +4983,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@4.17.21, lodash@^4.17.21:
+lodash@^4.17.21, lodash@4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5042,7 +5042,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@^1.1.1, make-error@1.x:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -5104,12 +5104,17 @@ mime-db@1.52.0:
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
+
+mime@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
+  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
 
 mime@1.6.0:
   version "1.6.0"
@@ -5121,25 +5126,10 @@ mime@2.6.0:
   resolved "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
 
-mime@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz"
-  integrity sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
-  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
-
-minimalistic-crypto-utils@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.2"
@@ -5162,9 +5152,9 @@ minimatch@^9.0.4:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
+minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
 minipass@^4.2.4:
@@ -5196,15 +5186,15 @@ mnemonist@0.39.5:
   dependencies:
     obliterator "^2.0.1"
 
+ms@^2.1.1, ms@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
   integrity sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==
-
-ms@2.1.2, ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"
-  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 ms@2.1.3:
   version "2.1.3"
@@ -5376,7 +5366,7 @@ on-exit-leak-free@^2.1.0:
   resolved "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz"
   integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
 
-on-finished@2.4.1, on-finished@^2.3.0:
+on-finished@^2.3.0, on-finished@2.4.1:
   version "2.4.1"
   resolved "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -5409,7 +5399,7 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
-ora@5.4.1, ora@^5.4.1:
+ora@^5.4.1, ora@5.4.1:
   version "5.4.1"
   resolved "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz"
   integrity sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==
@@ -5530,6 +5520,11 @@ path-scurry@^1.11.1, path-scurry@^1.6.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
+path-to-regexp@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz"
+  integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
@@ -5539,11 +5534,6 @@ path-to-regexp@3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.2.0.tgz"
   integrity sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==
-
-path-to-regexp@^6.1.0:
-  version "6.2.2"
-  resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz"
-  integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -5734,7 +5724,7 @@ qrcode@^1.5.3:
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
-qs@6.11.0, qs@^6.11.0:
+qs@^6.11.0, qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz"
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
@@ -5805,7 +5795,7 @@ rdf-canonize@^3.4.0:
 
 rdf-canonize@^5.0.0:
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-5.0.0.tgz#0bbad390c4beebaadf820e3888d495ac0b8cfb05"
+  resolved "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz"
   integrity sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==
   dependencies:
     setimmediate "^1.0.5"
@@ -5815,7 +5805,7 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-readable-stream@^2.2.2, readable-stream@~2.3.6:
+readable-stream@^2.2.2:
   version "2.3.8"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -5847,6 +5837,19 @@ readable-stream@^4.0.0:
     events "^3.3.0"
     process "^0.11.10"
     string_decoder "^1.3.0"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -5977,19 +5980,19 @@ rfdc@^1.2.0, rfdc@^1.3.0:
   resolved "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
-rimraf@4.4.1:
-  version "4.4.1"
-  resolved "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz"
-  integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
-  dependencies:
-    glob "^9.2.0"
-
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rimraf@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz"
+  integrity sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==
+  dependencies:
+    glob "^9.2.0"
 
 run-async@^2.4.0:
   version "2.4.1"
@@ -6003,7 +6006,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@7.8.1, rxjs@^7.2.0, rxjs@^7.5.5:
+rxjs@^7.2.0, rxjs@^7.5.5, rxjs@7.8.1:
   version "7.8.1"
   resolved "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz"
   integrity sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==
@@ -6020,9 +6023,9 @@ safe-array-concat@^1.1.2:
     has-symbols "^1.0.3"
     isarray "^2.0.5"
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2, safe-buffer@~5.2.0, safe-buffer@5.2.1:
   version "5.2.1"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
@@ -6051,7 +6054,7 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+safer-buffer@^2.0.2, safer-buffer@^2.1.0, "safer-buffer@>= 2.1.2 < 3", safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -6075,10 +6078,30 @@ security-context@^4.0.0:
   resolved "https://registry.npmjs.org/security-context/-/security-context-4.0.0.tgz"
   integrity sha512-yiDCS7tpKQl6p4NG57BdKLTSNLFfj5HosBIzXBl4jZf/qorJzSzbEUIdLhN+vVYgyLlvjixY8DPPTgqI8zvNCA==
 
-semver@^5.6.0, semver@^6.2.0, semver@^6.3.0, semver@^6.3.1, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4:
-  version "7.8.5"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
-  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+semver@^5.6.0:
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
+semver@^6.2.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.0, semver@^7.5.3, semver@^7.5.4:
+  version "7.7.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz"
+  integrity sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==
 
 send@0.18.0:
   version "0.18.0"
@@ -6140,9 +6163,9 @@ set-cookie-parser@^2.4.1:
   resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz"
   integrity sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ==
 
-set-function-length@^1.2.1, set-function-length@^1.2.2:
+set-function-length@^1.2.1:
   version "1.2.2"
-  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  resolved "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz"
   integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
   dependencies:
     define-data-property "^1.1.4"
@@ -6171,15 +6194,6 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
-
-sha.js@2.4.12:
-  version "2.4.12"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.12.tgz#eb8b568bf383dfd1867a32c3f2b74eb52bdbf23f"
-  integrity sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==
-  dependencies:
-    inherits "^2.0.4"
-    safe-buffer "^5.2.1"
-    to-buffer "^1.2.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -6212,7 +6226,17 @@ side-channel@^1.0.4:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-signal-exit@^3.0.2, signal-exit@^3.0.3, signal-exit@^3.0.7:
+signal-exit@^3.0.2:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -6256,6 +6280,14 @@ sonic-boom@^3.7.0:
   dependencies:
     atomic-sleep "^1.0.0"
 
+source-map-support@^0.5.20, source-map-support@~0.5.20, source-map-support@0.5.21:
+  version "0.5.21"
+  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz"
@@ -6264,23 +6296,20 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@0.5.21, source-map-support@^0.5.20, source-map-support@~0.5.20:
-  version "0.5.21"
-  resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 source-map@0.7.4:
   version "0.7.4"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
-
-source-map@^0.6.0, source-map@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 split2@^4.0.0:
   version "4.2.0"
@@ -6323,6 +6352,20 @@ streamsearch@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
+
+string_decoder@^1.1.1, string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 string-length@^4.0.1:
   version "4.0.2"
@@ -6386,20 +6429,6 @@ string.prototype.trimstart@^1.0.8:
     call-bind "^1.0.7"
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
-
-string_decoder@^1.1.1, string_decoder@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
-string_decoder@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
-  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
-  dependencies:
-    safe-buffer "~5.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
@@ -6575,15 +6604,6 @@ tmpl@1.0.5:
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
   integrity sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==
 
-to-buffer@^1.2.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.2.2.tgz#ffe59ef7522ada0a2d1cb5dfe03bb8abc3cdc133"
-  integrity sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==
-  dependencies:
-    isarray "^2.0.5"
-    safe-buffer "^5.2.1"
-    typed-array-buffer "^1.0.3"
-
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
@@ -6666,6 +6686,15 @@ tsconfig-paths-webpack-plugin@4.0.1:
     enhanced-resolve "^5.7.0"
     tsconfig-paths "^4.1.2"
 
+tsconfig-paths@^4.1.2:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz"
+  integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
+  dependencies:
+    json5 "^2.2.2"
+    minimist "^1.2.6"
+    strip-bom "^3.0.0"
+
 tsconfig-paths@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz"
@@ -6675,7 +6704,7 @@ tsconfig-paths@4.1.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tsconfig-paths@4.2.0, tsconfig-paths@^4.1.2:
+tsconfig-paths@4.2.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz"
   integrity sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==
@@ -6684,15 +6713,15 @@ tsconfig-paths@4.2.0, tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.5.3, tslib@^2.1.0:
-  version "2.5.3"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz"
-  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
-
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0, tslib@2.5.3:
+  version "2.5.3"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz"
+  integrity sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==
 
 tsutils@^3.21.0:
   version "3.21.0"
@@ -6756,15 +6785,6 @@ typed-array-buffer@^1.0.2:
     call-bind "^1.0.7"
     es-errors "^1.3.0"
     is-typed-array "^1.1.13"
-
-typed-array-buffer@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz#a72395450a4869ec033fd549371b47af3a2ee536"
-  integrity sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==
-  dependencies:
-    call-bound "^1.0.3"
-    es-errors "^1.3.0"
-    is-typed-array "^1.1.14"
 
 typed-array-byte-length@^1.0.1:
   version "1.0.1"
@@ -6852,17 +6872,17 @@ undici@^5.21.2:
   dependencies:
     "@fastify/busboy" "^2.0.0"
 
-undici@^6.23.0:
-  version "6.27.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.27.0.tgz#41f9e48f7c5a40d27376caaead8c9a9fc7bca9c4"
-  integrity sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==
+undici@^6.28.0:
+  version "6.28.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unpipe@1.0.0, unpipe@~1.0.0:
+unpipe@~1.0.0, unpipe@1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
@@ -6892,11 +6912,6 @@ utils-merge@1.0.1:
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
@@ -6906,6 +6921,11 @@ uuid@^9.0.0:
   version "9.0.1"
   resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz"
   integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
+uuid@9.0.0:
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -7042,19 +7062,6 @@ which-typed-array@^1.1.14, which-typed-array@^1.1.15:
     gopd "^1.0.1"
     has-tostringtag "^1.0.2"
 
-which-typed-array@^1.1.16:
-  version "1.1.22"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
-  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
-  dependencies:
-    available-typed-arrays "^1.0.7"
-    call-bind "^1.0.9"
-    call-bound "^1.0.4"
-    for-each "^0.3.5"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    has-tostringtag "^1.0.2"
-
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
@@ -7173,11 +7180,6 @@ yaml@^1.10.0:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yargs-parser@21.1.1, yargs-parser@^21.0.1, yargs-parser@^21.1.1:
-  version "21.1.1"
-  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
-  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
-
 yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz"
@@ -7185,6 +7187,11 @@ yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^21.0.1, yargs-parser@^21.1.1, yargs-parser@21.1.1:
+  version "21.1.1"
+  resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^15.3.1:
   version "15.4.1"

--- a/services/oid4vc-service/oid4vc-service.postman_collection.json
+++ b/services/oid4vc-service/oid4vc-service.postman_collection.json
@@ -776,6 +776,144 @@
       ]
     },
     {
+      "name": "4b. OID4VP - PEX Presentation Flow",
+      "item": [
+        {
+          "name": "Verifier creates PEX request",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{oid4vc_base}}/vp/request",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"presentation_definition\": {\n    \"id\": \"pex_pilot\",\n    \"input_descriptors\": [\n      {\n        \"id\": \"pilot_cred\",\n        \"format\": { \"ldp_vc\": {} },\n        \"constraints\": { \"fields\": [{ \"path\": [\"$.credentialSubject.name\"] }] }\n      }\n    ]\n  }\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('vp_transaction_id', json.transaction_id);",
+                  "pm.collectionVariables.set('vp_request_uri', json.request_uri);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Wallet fetches request object",
+          "request": {
+            "method": "GET",
+            "url": "{{vp_request_uri}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const payload = pm.response.json();",
+                  "pm.collectionVariables.set('vp_nonce', payload.nonce);",
+                  "pm.collectionVariables.set('vp_state', payload.state);",
+                  "pm.test('request object has nonce+state+presentation_definition', () => {",
+                  "  pm.expect(payload.nonce).to.not.be.undefined;",
+                  "  pm.expect(payload.presentation_definition).to.not.be.undefined;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Sign VP token (via identity-service, stand-in for wallet)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{identity_base}}/utils/sign-jwt",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"DID\": \"{{holder_did}}\",\n  \"payload\": {\n    \"aud\": \"{{oid4vc_base}}\",\n    \"nonce\": \"{{vp_nonce}}\",\n    \"vp\": { \"verifiableCredential\": [\"{{issued_credential}}\"] }\n  },\n  \"header\": { \"typ\": \"JWT\" }\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('vp_jwt', json.jwt);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Submit VP + presentation_submission (direct_post)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{oid4vc_base}}/vp/response",
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"state\": \"{{vp_state}}\",\n  \"vp_token\": \"{{vp_jwt}}\",\n  \"presentation_submission\": {\n    \"id\": \"{{$guid}}\",\n    \"definition_id\": \"pex_pilot\",\n    \"descriptor_map\": [{ \"id\": \"pilot_cred\", \"format\": \"ldp_vc\", \"path\": \"$\" }]\n  }\n}"
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test('status ok', () => {",
+                  "  pm.response.to.have.status(200);",
+                  "  pm.expect(pm.response.json().status).to.eql('ok');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Verifier polls status",
+          "request": {
+            "method": "GET",
+            "url": "{{oid4vc_base}}/vp/status/{{vp_transaction_id}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const json = pm.response.json();",
+                  "pm.test('all 6 checks OK incl. pex', () => {",
+                  "  pm.expect(json.verified).to.eql(true);",
+                  "  ['holderSignature','nonce','credentialSignatures','holderBinding','revocation','pex'].forEach(k => {",
+                  "    pm.expect(json.checks[k]).to.eql('OK');",
+                  "  });",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "5. OID4VP - Negative Tests",
       "item": [
         {

--- a/services/oid4vc-service/src/oid4vci/oid4vci.service.ts
+++ b/services/oid4vc-service/src/oid4vci/oid4vci.service.ts
@@ -89,7 +89,9 @@ export class Oid4vciService {
           scope: cfg.name,
           cryptographic_binding_methods_supported: ['did:web', 'did:key', 'jwk'],
           credential_signing_alg_values_supported: isMdoc ? ['ES256'] : ['ES256', 'Ed25519Signature2020'],
-          proof_types_supported: { jwt: { proof_signing_alg_values_supported: ['ES256'] } },
+          proof_types_supported: {
+            jwt: { proof_signing_alg_values_supported: isMdoc ? ['ES256'] : ['ES256', 'EdDSA'] },
+          },
           // vct MUST be a URI if it contains a ':', and some wallets resolve
           // EVERY vct as a URL regardless of that spec carve-out, so a bare
           // display name like "National Identity Credential" crashes them on
@@ -532,6 +534,14 @@ export class Oid4vciService {
         ? { docType: session.docType, namespaces: this.buildMdocNamespaces(session) }
         : {}),
     });
+
+    if (Array.isArray(res.credential?.['@context'])) {
+      res.credential['@context'] = res.credential['@context'].map((entry: string) =>
+        typeof entry === 'string' && entry.startsWith(this.config.internalUrl)
+          ? entry.replace(this.config.internalUrl, this.config.publicUrl)
+          : entry,
+      );
+    }
     return res.credential;
   }
 

--- a/services/oid4vc-service/src/oid4vp/dcql.service.ts
+++ b/services/oid4vc-service/src/oid4vp/dcql.service.ts
@@ -9,7 +9,7 @@ import { Injectable } from '@nestjs/common';
 // query or a presented credential can use either spelling without breaking
 // the other side.
 const SD_JWT_FORMAT_ALIASES = new Set(['vc+sd-jwt', 'dc+sd-jwt']);
-function sameFormat(a: string, b: string): boolean {
+export function sameFormat(a: string, b: string): boolean {
   if (a === b) return true;
   return SD_JWT_FORMAT_ALIASES.has(a) && SD_JWT_FORMAT_ALIASES.has(b);
 }

--- a/services/oid4vc-service/src/oid4vp/jsonpath.util.ts
+++ b/services/oid4vc-service/src/oid4vp/jsonpath.util.ts
@@ -1,0 +1,32 @@
+// Minimal JSONPath subset shared by PexService (constraints.fields[].path)
+// and Oid4vpService (descriptor_map[].path / path_nested.path resolution).
+// Supports dot-segments, ['bracket']/["bracket"] segments (needed for mdoc
+// namespace keys that contain dots, e.g. $['org.iso.18013.5.1']['given_name']),
+// and numeric [n] array indices.
+const TOKEN_RE = /\.([^.[\]]+)|\['([^']*)'\]|\["([^"]*)"\]|\[(\d+)\]/g;
+
+export function parseJsonPath(path: string): Array<string | number> {
+  if (typeof path !== 'string' || !path.startsWith('$')) return [];
+  const rest = path.slice(1);
+  const segments: Array<string | number> = [];
+  TOKEN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = TOKEN_RE.exec(rest))) {
+    const [, dotSeg, singleQuoted, doubleQuoted, index] = match;
+    segments.push(index !== undefined ? Number(index) : (dotSeg ?? singleQuoted ?? doubleQuoted ?? ''));
+  }
+  return segments;
+}
+
+export function walkSegments(obj: any, segments: Array<string | number>): any {
+  let cur = obj;
+  for (const seg of segments) {
+    if (cur == null) return undefined;
+    cur = cur[seg as any];
+  }
+  return cur;
+}
+
+export function resolveJsonPath(obj: any, path: string): any {
+  return walkSegments(obj, parseJsonPath(path));
+}

--- a/services/oid4vc-service/src/oid4vp/oid4vp.controller.ts
+++ b/services/oid4vc-service/src/oid4vp/oid4vp.controller.ts
@@ -26,8 +26,9 @@ export class Oid4vpController {
   // protocol endpoints.
   @ApiOperation({
     summary:
-      'Verifier creates a presentation request (DCQL). Signed draft-23 JAR by default; ' +
-      'pass {"signed": false} for an unsigned request, or set OID4VP_LEGACY_CLIENT_ID_SCHEME ' +
+      'Verifier creates a presentation request — exactly one of "dcql_query" or ' +
+      '"presentation_definition" (PEX). Signed draft-23 JAR by default; pass ' +
+      '{"signed": false} for an unsigned request, or set OID4VP_LEGACY_CLIENT_ID_SCHEME ' +
       'for the pre-draft-22 redirect_uri client_id_scheme shape.',
   })
   @ApiBearerAuth()

--- a/services/oid4vc-service/src/oid4vp/oid4vp.module.ts
+++ b/services/oid4vc-service/src/oid4vp/oid4vp.module.ts
@@ -2,12 +2,13 @@ import { Module } from '@nestjs/common';
 import { Oid4vpController } from './oid4vp.controller';
 import { Oid4vpService } from './oid4vp.service';
 import { DcqlService } from './dcql.service';
+import { PexService } from './pex.service';
 import { Oid4vciModule } from '../oid4vci/oid4vci.module';
 
 // Imports Oid4vciModule to reuse TokenService (issuer DID + JAR signing).
 @Module({
   imports: [Oid4vciModule],
   controllers: [Oid4vpController],
-  providers: [Oid4vpService, DcqlService],
+  providers: [Oid4vpService, DcqlService, PexService],
 })
 export class Oid4vpModule {}

--- a/services/oid4vc-service/src/oid4vp/oid4vp.service.spec.ts
+++ b/services/oid4vc-service/src/oid4vp/oid4vp.service.spec.ts
@@ -9,6 +9,7 @@ jest.mock('@auth0/mdl/lib/cbor', () => ({ cborEncode: jest.fn(), DataItem: {} })
 import { Oid4vpService } from './oid4vp.service';
 import { MemoryStoreService } from '../session/memory-store.service';
 import { DcqlService } from './dcql.service';
+import { PexService } from './pex.service';
 
 // Focused on the request-object builder (createRequest/getRequestObject) —
 // the three client_id/signing shapes described in the plan: signed
@@ -48,10 +49,12 @@ describe('Oid4vpService request-object modes', () => {
       credentials,
       tokens,
       new DcqlService(),
+      new PexService(),
     );
   }
 
   const dcqlQuery = { credentials: [{ id: 'c', meta: { type_values: [['X']] }, claims: [] }] };
+  const presentationDefinition = { input_descriptors: [{ id: 'c', constraints: { fields: [] } }] };
 
   it('signed mode (default): did: client_id, calls identity.signJwt, serves a JWS', async () => {
     process.env.VERIFIER_DID = 'did:web:verifier.example';
@@ -144,6 +147,30 @@ describe('Oid4vpService request-object modes', () => {
     const service = makeService();
     await service.createRequest({ dcql_query: dcqlQuery });
     expect(signJwt.mock.calls[0][0]).toBe('did:key:zExplicitOperatorChoice');
+  });
+
+  it('accepts presentation_definition and embeds it (not dcql_query) in the request object', async () => {
+    const service = makeService();
+    const created = await service.createRequest({
+      presentation_definition: presentationDefinition,
+      signed: false,
+    });
+    const id = created.request_uri.split('/').pop() as string;
+    const obj = await service.getRequestObject(id);
+    expect(obj.body.presentation_definition).toEqual(presentationDefinition);
+    expect(obj.body).not.toHaveProperty('dcql_query');
+  });
+
+  it('rejects when both dcql_query and presentation_definition are supplied', async () => {
+    const service = makeService();
+    await expect(
+      service.createRequest({ dcql_query: dcqlQuery, presentation_definition: presentationDefinition }),
+    ).rejects.toThrow(/exactly one of/);
+  });
+
+  it('rejects when neither dcql_query nor presentation_definition is supplied', async () => {
+    const service = makeService();
+    await expect(service.createRequest({})).rejects.toThrow(/exactly one of/);
   });
 
   it('signed mode with no VERIFIER_DID/ISSUER_DID/auto-provisioned DID at all throws instead of silently downgrading', async () => {

--- a/services/oid4vc-service/src/oid4vp/oid4vp.service.ts
+++ b/services/oid4vc-service/src/oid4vp/oid4vp.service.ts
@@ -14,6 +14,8 @@ import { IdentityClient } from '../clients/identity.client';
 import { CredentialsClient } from '../clients/credentials.client';
 import { TokenService } from '../oid4vci/token.service';
 import { DcqlService } from './dcql.service';
+import { PexService } from './pex.service';
+import { resolveJsonPath } from './jsonpath.util';
 import { loadConfig } from '../config/configuration';
 import * as jose from 'jose';
 import { buildSessionTranscript, verifyMdocPresentation } from './mdoc-presentation.util';
@@ -24,7 +26,9 @@ import {
 } from '../utils/self-contained-did.util';
 
 interface VpTxn {
-  dcqlQuery: any;
+  queryMode: 'dcql' | 'pex';
+  dcqlQuery?: any;
+  presentationDefinition?: any;
   nonce: string;
   state: string;
   status: 'pending' | 'verified' | 'failed';
@@ -50,6 +54,7 @@ export class Oid4vpService {
     private readonly credentials: CredentialsClient,
     private readonly tokens: TokenService,
     private readonly dcql: DcqlService,
+    private readonly pex: PexService,
   ) {}
 
   // client_id / scheme history, condensed from live interop testing against
@@ -76,7 +81,7 @@ export class Oid4vpService {
     responseUri: string,
     nonce: string,
     state: string,
-    dcqlQuery: any,
+    queryPayload: Record<string, any>,
     signed: boolean,
   ): Promise<{ mode: VpRequestMode; clientId: string; payload: any; jws?: string }> {
     if (this.config.vpLegacyClientIdScheme) {
@@ -88,7 +93,7 @@ export class Oid4vpService {
         response_uri: responseUri,
         nonce,
         state,
-        dcql_query: dcqlQuery,
+        ...queryPayload,
       };
       return { mode: 'legacy', clientId: payload.client_id, payload };
     }
@@ -101,7 +106,7 @@ export class Oid4vpService {
       response_uri: responseUri,
       nonce,
       state,
-      dcql_query: dcqlQuery,
+      ...queryPayload,
     };
 
     if (!signed) {
@@ -144,9 +149,24 @@ export class Oid4vpService {
     return { mode: 'signed', clientId: didClientId, payload: signedPayload, jws };
   }
 
-  // Verifier creates a presentation request.
-  async createRequest(body: { dcql_query: any; signed?: boolean }) {
-    if (!body?.dcql_query) throw new BadRequestException('dcql_query required');
+  // Verifier creates a presentation request — DCQL or PEX, mutually exclusive.
+  async createRequest(body: {
+    dcql_query?: any;
+    presentation_definition?: any;
+    signed?: boolean;
+    client_metadata?: any;
+  }) {
+    const hasDcql = !!body?.dcql_query;
+    const hasPex = !!body?.presentation_definition;
+    if (hasDcql === hasPex) {
+      throw new BadRequestException('exactly one of dcql_query or presentation_definition is required');
+    }
+    const queryMode: 'dcql' | 'pex' = hasDcql ? 'dcql' : 'pex';
+    const queryPayload = {
+      ...(hasDcql ? { dcql_query: body.dcql_query } : { presentation_definition: body.presentation_definition }),
+      ...(body.client_metadata ? { client_metadata: body.client_metadata } : {}),
+    };
+
     const id = uuid();
     const nonce = crypto.randomBytes(24).toString('base64url');
     const state = crypto.randomBytes(16).toString('base64url');
@@ -157,11 +177,17 @@ export class Oid4vpService {
       responseUri,
       nonce,
       state,
-      body.dcql_query,
+      queryPayload,
       signed,
     );
 
-    const txn: VpTxn = { dcqlQuery: body.dcql_query, nonce, state, status: 'pending' };
+    const txn: VpTxn = {
+      queryMode,
+      ...(hasDcql ? { dcqlQuery: body.dcql_query } : { presentationDefinition: body.presentation_definition }),
+      nonce,
+      state,
+      status: 'pending',
+    };
     await this.store.set(
       `oid4vp:txn:${id}`,
       { ...txn, requestObject: payload, requestObjectJws: jws, requestMode: mode, clientId, responseUri },
@@ -171,9 +197,14 @@ export class Oid4vpService {
     await this.store.set(`oid4vp:state:${state}`, { id }, this.config.ttl.vpTxn);
 
     const requestUri = `${this.config.publicUrl}/vp/request-object/${id}`;
-    const link = `openid4vp://?client_id=${encodeURIComponent(
-      clientId,
-    )}&request_uri=${encodeURIComponent(requestUri)}`;
+    const link =
+      mode === 'signed'
+        ? `openid4vp://authorize?client_id=${encodeURIComponent(clientId)}&request=${encodeURIComponent(jws!)}`
+        : `openid4vp://authorize?${new URLSearchParams(
+            Object.fromEntries(
+              Object.entries(payload).map(([k, v]) => [k, typeof v === 'string' ? v : JSON.stringify(v)]),
+            ),
+          ).toString()}`;
 
     return { transaction_id: id, request_uri: requestUri, qr_data: link };
   }
@@ -215,268 +246,104 @@ export class Oid4vpService {
 
     const checks: Record<string, string> = {};
     try {
-      let vpToken = body.vp_token;
-      if (!vpToken) throw new Error('missing vp_token');
-
-      // direct_post sends the Authorization Response as
-      // application/x-www-form-urlencoded (OID4VP §Response Mode
-      // "direct_post"), so `vp_token` arrives as a JSON-encoded STRING, not a
-      // pre-parsed object — Fastify's form parser has no notion of a nested
-      // JSON value. A real wallet's POST body has `vp_token: '{"q":["..."]}'`
-      // (a string); JSON.parse it before treating it as the DCQL-keyed object.
-      if (typeof vpToken === 'string') {
-        try {
-          vpToken = JSON.parse(vpToken);
-        } catch {
-          throw new Error('vp_token is not valid JSON');
-        }
-      }
-
-      // Per OID4VP §Response Parameters, `vp_token` is a JSON object keyed by
-      // the DCQL credential query `id`, each value an array of Presentations
-      // — NOT a bare JWT or an array of JWTs. A real wallet's response is
-      // `{ [queryId]: [presentation, ...] }`; treating the whole object as a
-      // single JWT-VP instead throws a token/header parsing error before any
-      // per-credential parsing even starts.
-      if (typeof vpToken !== 'object' || Array.isArray(vpToken)) {
-        throw new Error(
-          "vp_token must be a DCQL-keyed object of the form { [queryId]: [presentation, ...] }",
-        );
-      }
-
-      const dcqlCredentials = txn.dcqlQuery?.credentials || [];
-      if (!dcqlCredentials.length) throw new Error('txn has no DCQL credential queries');
+      if (!body.vp_token) throw new Error('missing vp_token');
 
       let holderDid: string | undefined;
       const presented: Array<any> = [];
+      let matched: Record<string, any> = {};
 
-      for (const cq of dcqlCredentials) {
-        const entries = vpToken[cq.id];
-        if (!Array.isArray(entries) || !entries.length) {
-          throw new Error(`no presentation submitted for query '${cq.id}'`);
+      if (txn.queryMode === 'pex') {
+        const vpTokenArr = this.normalizePexVpToken(body.vp_token);
+        let submission = body.presentation_submission;
+        if (typeof submission === 'string') {
+          try {
+            submission = JSON.parse(submission);
+          } catch {
+            throw new Error('presentation_submission is not valid JSON');
+          }
         }
-        const entry = entries[0];
+        if (!submission || !Array.isArray(submission.descriptor_map)) {
+          throw new Error('missing or invalid presentation_submission');
+        }
 
-        if (cq.format === 'mso_mdoc') {
-          // mso_mdoc presentation: the entry is a base64url CBOR
-          // DeviceResponse, not a JWT-VP wrapper — a genuinely different wire
-          // shape from the other formats (see mdoc-presentation.util.ts).
-          const mdocGeneratedNonce = body.mdoc_generated_nonce;
-          if (!mdocGeneratedNonce) throw new Error('missing mdoc_generated_nonce');
-          const clientId = txn.requestObject?.client_id;
-          const responseUri = txn.requestObject?.response_uri;
-          const transcript = buildSessionTranscript(mdocGeneratedNonce, clientId, responseUri, txn.nonce);
-          const mdocResult = await verifyMdocPresentation(entry, transcript);
-          if (!mdocResult.verified) throw new Error(`mdoc presentation invalid: ${mdocResult.error}`);
-          if (!mdocResult.documents.length) throw new Error('no documents in mdoc presentation');
-
-          // @auth0/mdl's Verifier.verify() already covers, in one call: the
-          // issuer's COSE signature + per-item digests (credentialSignatures),
-          // and the device's COSE signature against deviceKeyInfo.deviceKey
-          // computed over the session transcript we built from txn.nonce
-          // (holderSignature + nonce + holderBinding all at once — a mismatch
-          // in ANY of client_id/response_uri/nonce produces different
-          // transcript bytes than what the wallet actually signed over, so
-          // Verifier.verify() fails there instead of a separate explicit check).
-          checks.holderSignature = 'OK';
-          checks.nonce = 'OK';
-          checks.credentialSignatures = 'OK';
-          checks.holderBinding = 'OK';
-          checks.revocation = 'OK'; // no mdoc revocation mechanism wired yet — same default as other formats
-          presented.push(
-            ...mdocResult.documents.map((doc) => ({
-              types: [],
-              docType: doc.docType,
-              format: 'mso_mdoc',
-              claims: doc.claims,
-            })),
+        const descriptors = txn.presentationDefinition?.input_descriptors || [];
+        for (const dm of submission.descriptor_map) {
+          const descriptor = descriptors.find((d: any) => d.id === dm.id);
+          if (!descriptor) throw new Error(`unknown descriptor id '${dm.id}' in presentation_submission`);
+          const resolved = this.resolveDescriptorMapEntry(vpTokenArr, dm);
+          const { presented: push, holderDid: hd } = await this.verifyPresentationEntry(
+            resolved.value,
+            resolved.format,
+            txn,
+            body,
+            checks,
           );
-          continue;
+          presented.push(...push);
+          if (!holderDid && hd) holderDid = hd;
         }
 
-        if (cq.format === 'dc+sd-jwt' || cq.format === 'vc+sd-jwt') {
-          // The Presentation *is* the SD-JWT+KB compact string directly —
-          // there is no outer VP-JWT wrapper for this format. The Key Binding
-          // JWT trailing it carries the `nonce`/`aud` that prove holder
-          // binding + replay protection (OID4VP "IETF SD-JWT VC" Presentation
-          // Response). Delegate that whole check to credentials-service,
-          // which already implements it end-to-end via identity-service's
-          // verifySdJwt (issuer signature, disclosure digests, KB-JWT
-          // signature against the issuer-embedded `cnf.jwk`, and nonce/aud) —
-          // the same call path already used for issuance-time PoP, just with
-          // challenge/domain now supplied.
-          const verifyRes = await this.credentials.verify(entry, {
-            challenge: txn.nonce,
-            domain: txn.clientId,
-          });
-          const vcChecks = verifyRes?.checks?.[0] || {};
-          if (vcChecks.proof !== 'OK') {
-            throw new Error('SD-JWT+KB presentation invalid (signature, nonce, or audience)');
-          }
-          if (vcChecks.revoked === 'NOK') throw new Error('embedded VC revoked');
-          checks.holderSignature = 'OK';
-          checks.nonce = 'OK';
-          checks.audience = 'OK';
-          checks.credentialSignatures = 'OK';
-          checks.holderBinding = 'OK';
-          checks.revocation = 'OK';
+        const pexResult = this.pex.evaluate(txn.presentationDefinition, presented);
+        if (!pexResult.satisfied) throw new Error(`PEX not satisfied: ${pexResult.reason}`);
+        checks.pex = 'OK';
+        matched = pexResult.matched;
+      } else {
+        let vpToken = body.vp_token;
 
-          // Claim reconstruction is independent of the trust check above —
-          // extractCredentials() already tolerates a trailing KB-JWT segment
-          // (silently skipped as an unparseable "disclosure").
-          const [parsed] = this.extractCredentials({ verifiableCredential: [entry] });
-          if (!parsed) throw new Error('unable to parse SD-JWT claims');
-          if (!holderDid && parsed.subjectId) holderDid = parsed.subjectId;
-          presented.push({ types: parsed.types, vct: parsed.vct, format: cq.format, claims: parsed.claims });
-          continue;
+        // direct_post sends the Authorization Response as
+        // application/x-www-form-urlencoded (OID4VP §Response Mode
+        // "direct_post"), so `vp_token` arrives as a JSON-encoded STRING, not
+        // a pre-parsed object — Fastify's form parser has no notion of a
+        // nested JSON value. A real wallet's POST body has
+        // `vp_token: '{"q":["..."]}'` (a string); JSON.parse it before
+        // treating it as the DCQL-keyed object.
+        if (typeof vpToken === 'string') {
+          try {
+            vpToken = JSON.parse(vpToken);
+          } catch {
+            throw new Error('vp_token is not valid JSON');
+          }
         }
 
-        // jwt_vc_json / ldp_vc: the Presentation is itself a Verifiable
-        // Presentation carrying its own nonce/aud (JWT-VP) or challenge/domain
-        // (LD-proof VP), wrapping the embedded credential(s).
-        if (typeof entry === 'string') {
-          const vpHeader = jose.decodeProtectedHeader(entry);
-          const vpClaims: any = jose.decodeJwt(entry);
-
-          const holderKid = vpHeader.kid as string;
-          let entryHolderDid = holderKid ? holderKid.split('#')[0] : vpClaims.iss;
-          let holderPublicJwk: any = vpHeader.jwk as any;
-
-          // did:jwk wallets commonly sign with an inline `jwk` header and no
-          // `kid`/`iss`, or a self-contained `did:jwk:...` DID; others present
-          // with the `did:key` they bound at issuance. Neither is resolvable
-          // via identity-service's registry, which only knows its own DB plus
-          // did:web (see did.service.ts resolveDID: any other method 404s).
-          // Both methods are deterministic by spec — the public key is
-          // embedded in the identifier — so resolve locally instead of
-          // round-tripping to identity-service. Mirrors the same fallback
-          // applied to the issuance-side PoP check in pop.service.ts.
-          //
-          // An inline `jwk` header is self-asserted; if `kid`/`iss` also
-          // claims a holder DID, that DID's actual key — not the header —
-          // must be trusted. Verify the two agree for self-contained DIDs;
-          // reject an inline jwk alongside any registry-resolved DID method
-          // outright, since its real key can only come from resolution.
-          // Otherwise the holder-binding check below (subjectId ===
-          // entryHolderDid) compares the embedded VC's subject against a DID
-          // the presenter never actually proved control of.
-          if (holderPublicJwk && entryHolderDid) {
-            if (isSelfContainedDid(entryHolderDid)) {
-              if (!jwkPublicKeyEquals(resolveSelfContainedDidToJwk(entryHolderDid), holderPublicJwk)) {
-                throw new Error('holder DID does not match inline jwk header');
-              }
-            } else {
-              throw new Error('inline jwk header not permitted alongside a registry-resolved holder DID');
-            }
-          }
-          if (!holderPublicJwk) {
-            holderPublicJwk = resolveSelfContainedDidToJwk(entryHolderDid);
-          }
-          if (!holderPublicJwk) {
-            const holderDidDoc = await this.identity.resolveDID(entryHolderDid);
-            const holderVm = (holderDidDoc.verificationMethod || []).find(
-              (m: any) => (holderKid ? m.id === holderKid : true) && m.publicKeyJwk,
-            );
-            if (!holderVm) throw new Error('holder key not resolvable');
-            holderPublicJwk = holderVm.publicKeyJwk;
-          }
-          if (!entryHolderDid) {
-            entryHolderDid = `did:jwk:${Buffer.from(JSON.stringify(holderPublicJwk)).toString('base64url')}`;
-          }
-          const holderKey = await jose.importJWK(holderPublicJwk, (vpHeader.alg as string) || 'ES256');
-          await jose.compactVerify(entry, holderKey);
-          checks.holderSignature = 'OK';
-
-          if (vpClaims.nonce !== txn.nonce) throw new Error('nonce mismatch');
-          checks.nonce = 'OK';
-
-          // A VP token bound to a different verifier's client_id (e.g. replayed
-          // against this endpoint after being obtained by another relying
-          // party) must be rejected here — the request's own client_id is the
-          // only value that anchors "who this presentation was made to".
-          const aud = vpClaims.aud;
-          const audMatches = Array.isArray(aud) ? aud.includes(txn.clientId) : aud === txn.clientId;
-          if (!audMatches) throw new Error('audience mismatch');
-          checks.audience = 'OK';
-
-          const vp = vpClaims.vp || vpClaims;
-          const embedded = this.extractCredentials(vp);
-          if (!embedded.length) throw new Error('no verifiable credentials in VP');
-
-          // Per-VC signature verify (delegated) + holder binding + status.
-          //
-          // Deliberately NOT passing {challenge: txn.nonce, domain: ...} here.
-          // That was found live to break every ldp_vc presentation: the embedded
-          // VC's proof is a static assertion signature created once at issuance
-          // time, long before this (or any) presentation's nonce existed, so
-          // credentials-service's checkChallengeDomain() would require an
-          // impossible match and always fail proof:'OK'. Replay/freshness
-          // protection for the PRESENTATION is already correctly enforced above
-          // (the JWT-VP wrapper's own `nonce` claim check) — passing the
-          // presentation's nonce down into the embedded credential's own
-          // signature check applies that protection at the wrong layer.
-          for (const vc of embedded) {
-            const verifyRes = await this.credentials.verify(vc.raw);
-            const proofOk = verifyRes?.checks?.[0]?.proof === 'OK';
-            const notRevoked = verifyRes?.checks?.[0]?.revoked !== 'NOK';
-            if (!proofOk) throw new Error('embedded VC signature invalid');
-            if (!notRevoked) throw new Error('embedded VC revoked');
-
-            // holder binding: subject id must equal the VP signer. Fail closed
-            // (rather than skip) when the embedded VC carries no subject id at
-            // all — otherwise a credential with no credentialSubject.id/sub
-            // would silently report holderBinding: 'OK' with nothing actually
-            // compared.
-            const subjectId = vc.claims?.id || vc.claims?.sub || vc.subjectId;
-            if (!subjectId || subjectId !== entryHolderDid) {
-              throw new Error('holder binding failed: missing or mismatched subject id');
-            }
-            presented.push({
-              types: vc.types,
-              vct: vc.vct,
-              format: vc.format,
-              claims: vc.claims,
-            });
-          }
-          if (!holderDid) holderDid = entryHolderDid;
-          checks.credentialSignatures = 'OK';
-          checks.holderBinding = 'OK';
-          checks.revocation = 'OK';
-        } else {
-          // ldp_vc as a plain Data Integrity VP object — challenge/domain
-          // live on the LD proof itself rather than JWT claims.
-          const proof = entry?.proof || {};
-          if (proof.challenge && proof.challenge !== txn.nonce) throw new Error('nonce mismatch');
-          if (proof.domain && proof.domain !== txn.clientId) throw new Error('audience mismatch');
-          checks.nonce = 'OK';
-          checks.audience = 'OK';
-          const verifyRes = await this.credentials.verify(entry, {
-            challenge: txn.nonce,
-            domain: txn.clientId,
-          });
-          const proofOk = verifyRes?.checks?.[0]?.proof === 'OK';
-          if (!proofOk) throw new Error('ldp_vc presentation invalid');
-          checks.holderSignature = 'OK';
-          checks.credentialSignatures = 'OK';
-          // This branch has no separate outer-VP holder signature distinct
-          // from the credential's own proof — the closest thing to a holder
-          // binding check available here is requiring a subject id to exist
-          // at all, rather than unconditionally reporting 'OK'.
-          const subject = entry.credentialSubject || {};
-          if (!subject.id) throw new Error('holder binding failed: missing subject id');
-          checks.holderBinding = 'OK';
-          checks.revocation = 'OK';
-          presented.push({ types: entry.type || ['VerifiableCredential'], format: 'ldp_vc', claims: subject });
+        // Per OID4VP §Response Parameters, `vp_token` is a JSON object keyed
+        // by the DCQL credential query `id`, each value an array of
+        // Presentations — NOT a bare JWT or an array of JWTs. A real
+        // wallet's response is `{ [queryId]: [presentation, ...] }`;
+        // treating the whole object as a single JWT-VP instead throws a
+        // token/header parsing error before any per-credential parsing even
+        // starts.
+        if (typeof vpToken !== 'object' || Array.isArray(vpToken)) {
+          throw new Error(
+            "vp_token must be a DCQL-keyed object of the form { [queryId]: [presentation, ...] }",
+          );
         }
+
+        const dcqlCredentials = txn.dcqlQuery?.credentials || [];
+        if (!dcqlCredentials.length) throw new Error('txn has no DCQL credential queries');
+
+        for (const cq of dcqlCredentials) {
+          const entries = vpToken[cq.id];
+          if (!Array.isArray(entries) || !entries.length) {
+            throw new Error(`no presentation submitted for query '${cq.id}'`);
+          }
+          const { presented: push, holderDid: hd } = await this.verifyPresentationEntry(
+            entries[0],
+            cq.format,
+            txn,
+            body,
+            checks,
+          );
+          presented.push(...push);
+          if (!holderDid && hd) holderDid = hd;
+        }
+
+        const dcqlResult = this.dcql.evaluate(txn.dcqlQuery, presented);
+        if (!dcqlResult.satisfied) throw new Error(`DCQL not satisfied: ${dcqlResult.reason}`);
+        checks.dcql = 'OK';
+        matched = dcqlResult.matched;
       }
 
-      // DCQL satisfaction.
-      const dcqlResult = this.dcql.evaluate(txn.dcqlQuery, presented);
-      if (!dcqlResult.satisfied) throw new Error(`DCQL not satisfied: ${dcqlResult.reason}`);
-      checks.dcql = 'OK';
-
       // Store the result.
-      const result = { verified: true, checks, claims: dcqlResult.matched, holderDid };
+      const result = { verified: true, checks, claims: matched, holderDid };
       await this.store.set(key, { ...txn, status: 'verified', result }, this.config.ttl.vpTxn);
       return { redirect_uri: null, status: 'ok' };
     } catch (err) {
@@ -485,6 +352,326 @@ export class Oid4vpService {
       await this.store.set(key, { ...txn, status: 'failed', result }, this.config.ttl.vpTxn);
       throw new ForbiddenException(result);
     }
+  }
+
+  // Verifies one presented entry (one credential/presentation, already
+  // resolved from either a DCQL credential-query slot or a PEX
+  // descriptor_map entry) and returns the presented[]-shaped items it
+  // yields plus any holder DID it establishes. Shared by both query modes —
+  // the per-format checks below don't care which query language selected
+  // this entry.
+  private async verifyPresentationEntry(
+    entry: any,
+    format: string,
+    txn: any,
+    body: any,
+    checks: Record<string, string>,
+  ): Promise<{ presented: any[]; holderDid?: string }> {
+    if (format === 'mso_mdoc') {
+      // mso_mdoc presentation: the entry is a base64url CBOR DeviceResponse,
+      // not a JWT-VP wrapper — a genuinely different wire shape from the
+      // other formats (see mdoc-presentation.util.ts).
+      const mdocGeneratedNonce = body.mdoc_generated_nonce;
+      if (!mdocGeneratedNonce) throw new Error('missing mdoc_generated_nonce');
+      const clientId = txn.requestObject?.client_id;
+      const responseUri = txn.requestObject?.response_uri;
+      const transcript = buildSessionTranscript(mdocGeneratedNonce, clientId, responseUri, txn.nonce);
+      const mdocResult = await verifyMdocPresentation(entry, transcript);
+      if (!mdocResult.verified) throw new Error(`mdoc presentation invalid: ${mdocResult.error}`);
+      if (!mdocResult.documents.length) throw new Error('no documents in mdoc presentation');
+
+      // @auth0/mdl's Verifier.verify() already covers, in one call: the
+      // issuer's COSE signature + per-item digests (credentialSignatures),
+      // and the device's COSE signature against deviceKeyInfo.deviceKey
+      // computed over the session transcript we built from txn.nonce
+      // (holderSignature + nonce + holderBinding all at once — a mismatch
+      // in ANY of client_id/response_uri/nonce produces different
+      // transcript bytes than what the wallet actually signed over, so
+      // Verifier.verify() fails there instead of a separate explicit check).
+      checks.holderSignature = 'OK';
+      checks.nonce = 'OK';
+      checks.credentialSignatures = 'OK';
+      checks.holderBinding = 'OK';
+      checks.revocation = 'OK'; // no mdoc revocation mechanism wired yet — same default as other formats
+      return {
+        presented: mdocResult.documents.map((doc) => ({
+          types: [],
+          docType: doc.docType,
+          format: 'mso_mdoc',
+          claims: doc.claims,
+        })),
+      };
+    }
+
+    if (format === 'dc+sd-jwt' || format === 'vc+sd-jwt') {
+      // The Presentation *is* the SD-JWT+KB compact string directly — there
+      // is no outer VP-JWT wrapper for this format. The Key Binding JWT
+      // trailing it carries the `nonce`/`aud` that prove holder binding +
+      // replay protection (OID4VP "IETF SD-JWT VC" Presentation Response).
+      // Delegate that whole check to credentials-service, which already
+      // implements it end-to-end via identity-service's verifySdJwt (issuer
+      // signature, disclosure digests, KB-JWT signature against the
+      // issuer-embedded `cnf.jwk`, and nonce/aud) — the same call path
+      // already used for issuance-time PoP, just with challenge/domain now
+      // supplied.
+      const verifyRes = await this.credentials.verify(entry, {
+        challenge: txn.nonce,
+        domain: txn.clientId,
+      });
+      const vcChecks = verifyRes?.checks?.[0] || {};
+      if (vcChecks.proof !== 'OK') {
+        throw new Error('SD-JWT+KB presentation invalid (signature, nonce, or audience)');
+      }
+      if (vcChecks.revoked === 'NOK') throw new Error('embedded VC revoked');
+      checks.holderSignature = 'OK';
+      checks.nonce = 'OK';
+      checks.audience = 'OK';
+      checks.credentialSignatures = 'OK';
+      checks.holderBinding = 'OK';
+      checks.revocation = 'OK';
+
+      // Claim reconstruction is independent of the trust check above —
+      // extractCredentials() already tolerates a trailing KB-JWT segment
+      // (silently skipped as an unparseable "disclosure").
+      const [parsed] = this.extractCredentials({ verifiableCredential: [entry] });
+      if (!parsed) throw new Error('unable to parse SD-JWT claims');
+      return {
+        presented: [{ types: parsed.types, vct: parsed.vct, format, claims: parsed.claims }],
+        holderDid: parsed.subjectId,
+      };
+    }
+
+    // jwt_vc_json / ldp_vc: the Presentation is itself a Verifiable
+    // Presentation carrying its own nonce/aud (JWT-VP) or challenge/domain
+    // (LD-proof VP), wrapping the embedded credential(s).
+    if (typeof entry === 'string') {
+      const vpHeader = jose.decodeProtectedHeader(entry);
+      const vpClaims: any = jose.decodeJwt(entry);
+
+      const holderKid = vpHeader.kid as string;
+      let entryHolderDid = holderKid ? holderKid.split('#')[0] : vpClaims.iss;
+      let holderPublicJwk: any = vpHeader.jwk as any;
+
+      // did:jwk wallets commonly sign with an inline `jwk` header and no
+      // `kid`/`iss`, or a self-contained `did:jwk:...` DID; others present
+      // with the `did:key` they bound at issuance. Neither is resolvable
+      // via identity-service's registry, which only knows its own DB plus
+      // did:web (see did.service.ts resolveDID: any other method 404s).
+      // Both methods are deterministic by spec — the public key is
+      // embedded in the identifier — so resolve locally instead of
+      // round-tripping to identity-service. Mirrors the same fallback
+      // applied to the issuance-side PoP check in pop.service.ts.
+      //
+      // An inline `jwk` header is self-asserted; if `kid`/`iss` also
+      // claims a holder DID, that DID's actual key — not the header —
+      // must be trusted. Verify the two agree for self-contained DIDs;
+      // reject an inline jwk alongside any registry-resolved DID method
+      // outright, since its real key can only come from resolution.
+      // Otherwise the holder-binding check below (subjectId ===
+      // entryHolderDid) compares the embedded VC's subject against a DID
+      // the presenter never actually proved control of.
+      if (holderPublicJwk && entryHolderDid) {
+        if (isSelfContainedDid(entryHolderDid)) {
+          if (!jwkPublicKeyEquals(resolveSelfContainedDidToJwk(entryHolderDid), holderPublicJwk)) {
+            throw new Error('holder DID does not match inline jwk header');
+          }
+        } else {
+          throw new Error('inline jwk header not permitted alongside a registry-resolved holder DID');
+        }
+      }
+      if (!holderPublicJwk) {
+        holderPublicJwk = resolveSelfContainedDidToJwk(entryHolderDid);
+      }
+      if (!holderPublicJwk) {
+        const holderDidDoc = await this.identity.resolveDID(entryHolderDid);
+        const holderVm = (holderDidDoc.verificationMethod || []).find(
+          (m: any) => (holderKid ? m.id === holderKid : true) && m.publicKeyJwk,
+        );
+        if (!holderVm) throw new Error('holder key not resolvable');
+        holderPublicJwk = holderVm.publicKeyJwk;
+      }
+      if (!entryHolderDid) {
+        entryHolderDid = `did:jwk:${Buffer.from(JSON.stringify(holderPublicJwk)).toString('base64url')}`;
+      }
+      const holderKey = await jose.importJWK(holderPublicJwk, (vpHeader.alg as string) || 'ES256');
+      await jose.compactVerify(entry, holderKey);
+      checks.holderSignature = 'OK';
+
+      if (vpClaims.nonce !== txn.nonce) throw new Error('nonce mismatch');
+      checks.nonce = 'OK';
+
+      // A VP token bound to a different verifier's client_id (e.g. replayed
+      // against this endpoint after being obtained by another relying
+      // party) must be rejected here — the request's own client_id is the
+      // only value that anchors "who this presentation was made to".
+      const aud = vpClaims.aud;
+      const audMatches = Array.isArray(aud) ? aud.includes(txn.clientId) : aud === txn.clientId;
+      if (!audMatches) throw new Error('audience mismatch');
+      checks.audience = 'OK';
+
+      const vp = vpClaims.vp || vpClaims;
+      const embedded = this.extractCredentials(vp);
+      if (!embedded.length) throw new Error('no verifiable credentials in VP');
+
+      // Per-VC signature verify (delegated) + holder binding + status.
+      //
+      // Deliberately NOT passing {challenge: txn.nonce, domain: ...} here.
+      // That was found live to break every ldp_vc presentation: the embedded
+      // VC's proof is a static assertion signature created once at issuance
+      // time, long before this (or any) presentation's nonce existed, so
+      // credentials-service's checkChallengeDomain() would require an
+      // impossible match and always fail proof:'OK'. Replay/freshness
+      // protection for the PRESENTATION is already correctly enforced above
+      // (the JWT-VP wrapper's own `nonce` claim check) — passing the
+      // presentation's nonce down into the embedded credential's own
+      // signature check applies that protection at the wrong layer.
+      const presented: any[] = [];
+      for (const vc of embedded) {
+        const verifyRes = await this.credentials.verify(vc.raw);
+        const proofOk = verifyRes?.checks?.[0]?.proof === 'OK';
+        const notRevoked = verifyRes?.checks?.[0]?.revoked !== 'NOK';
+        if (!proofOk) throw new Error('embedded VC signature invalid');
+        if (!notRevoked) throw new Error('embedded VC revoked');
+
+        // holder binding: subject id must equal the VP signer. Fail closed
+        // (rather than skip) when the embedded VC carries no subject id at
+        // all — otherwise a credential with no credentialSubject.id/sub
+        // would silently report holderBinding: 'OK' with nothing actually
+        // compared.
+        const subjectId = vc.claims?.id || vc.claims?.sub || vc.subjectId;
+        if (!subjectId || subjectId !== entryHolderDid) {
+          throw new Error('holder binding failed: missing or mismatched subject id');
+        }
+        presented.push({
+          types: vc.types,
+          vct: vc.vct,
+          format: vc.format,
+          claims: vc.claims,
+        });
+      }
+      checks.credentialSignatures = 'OK';
+      checks.holderBinding = 'OK';
+      checks.revocation = 'OK';
+      return { presented, holderDid: entryHolderDid };
+    }
+
+    // ldp_vc as a full Data Integrity VerifiablePresentation object — `entry`
+    // is the VP wrapper, not the credential (confirmed live against a real
+    // wallet: it submits { type: ['VerifiablePresentation'], holder,
+    // verifiableCredential: [...], proof: { challenge, domain, proofPurpose:
+    // 'authentication', ... } }). The VP's own holder-binding proof carries
+    // challenge/domain; each embedded VC has its own separate (static,
+    // issuance-time, no challenge/domain) assertion proof — same split the
+    // jwt_vc_json/ldp_vc-JWT branch above already applies via extractCredentials().
+    const holderDid: string | undefined = (
+      typeof entry.holder === 'string' ? entry.holder : entry.holder?.id
+    )?.split('#')[0];
+    const proof = entry?.proof || {};
+    if (proof.challenge && proof.challenge !== txn.nonce) throw new Error('nonce mismatch');
+    if (proof.domain && proof.domain !== txn.clientId) throw new Error('audience mismatch');
+    checks.nonce = 'OK';
+    checks.audience = 'OK';
+
+    // Verifies the VP's OWN proof (holder-binding, `authentication` purpose)
+    // — not any embedded VC's assertion proof.
+    const vpVerifyRes = await this.credentials.verify(entry, {
+      challenge: txn.nonce,
+      domain: txn.clientId,
+    });
+    if (vpVerifyRes?.checks?.[0]?.proof !== 'OK') throw new Error('ldp_vc presentation invalid');
+    checks.holderSignature = 'OK';
+
+    const embedded = this.extractCredentials(entry);
+    if (!embedded.length) throw new Error('no verifiable credentials in VP');
+
+    const presented: any[] = [];
+    for (const vc of embedded) {
+      // Deliberately NOT passing {challenge, domain} here — same reasoning
+      // as the jwt_vc_json/ldp_vc-JWT branch above: the embedded VC's proof
+      // is a static assertion signature from issuance time, long before this
+      // presentation's nonce existed.
+      const verifyRes = await this.credentials.verify(vc.raw);
+      const proofOk = verifyRes?.checks?.[0]?.proof === 'OK';
+      const notRevoked = verifyRes?.checks?.[0]?.revoked !== 'NOK';
+      if (!proofOk) throw new Error('embedded VC signature invalid');
+      if (!notRevoked) throw new Error('embedded VC revoked');
+
+      const subjectId = vc.claims?.id || vc.claims?.sub || vc.subjectId;
+      if (!subjectId || subjectId !== holderDid) {
+        throw new Error('holder binding failed: missing or mismatched subject id');
+      }
+      presented.push({ types: vc.types, vct: vc.vct, format: vc.format, claims: vc.claims });
+    }
+    checks.credentialSignatures = 'OK';
+    checks.holderBinding = 'OK';
+    checks.revocation = 'OK';
+    return { presented, holderDid };
+  }
+
+  // PEX's vp_token wire shape differs from DCQL's: with exactly one
+  // presentation, vp_token is the raw presentation itself — for
+  // string-shaped formats (compact JWT-VP, SD-JWT+KB, base64url mdoc) that
+  // means it is NOT JSON at all, so JSON.parse failing here means "bare
+  // compact-string presentation," not an error (unlike DCQL's vp_token,
+  // which is always a JSON-encoded object).
+  private normalizePexVpToken(raw: any): any[] {
+    let v = raw;
+    if (typeof v === 'string') {
+      try {
+        v = JSON.parse(v);
+      } catch {
+        return [raw];
+      }
+    }
+    return Array.isArray(v) ? v : [v];
+  }
+
+  // Resolves one presentation_submission descriptor_map entry (path +
+  // optional path_nested chain) against the normalized vp_token array.
+  private resolveDescriptorMapEntry(vpTokenArr: any[], dm: any): { value: any; format: string } {
+    let value = this.resolveTopLevelPath(vpTokenArr, dm.path);
+    if (value === undefined) throw new Error(`presentation_submission path '${dm.path}' did not resolve`);
+    let format = dm.format;
+    let nested = dm.path_nested;
+
+    if (format === 'ldp_vp') return { value, format: 'ldp_vc' };
+
+    // ponytail: no depth cap beyond the chain's own length — a definition
+    // author controls their own definition's nesting depth.
+    while (nested) {
+      if (format === 'mso_mdoc' || format === 'vc+sd-jwt' || format === 'dc+sd-jwt') {
+        throw new Error(`path_nested is not supported for format '${format}'`);
+      }
+      const decoded = this.decodeForTraversal(value);
+      value = resolveJsonPath(decoded, nested.path);
+      if (value === undefined) throw new Error(`presentation_submission path_nested '${nested.path}' did not resolve`);
+      format = nested.format || format;
+      nested = nested.path_nested;
+    }
+    return { value, format };
+  }
+
+  // descriptor_map[].path only ever needs to index the top-level vp_token
+  // array — `$` for the single-presentation case, `$[n]` for the multiple
+  // case. Deeper paths belong to path_nested, resolved separately against
+  // the presentation's own decoded content.
+  private resolveTopLevelPath(vpTokenArr: any[], path: string): any {
+    if (path === '$') return vpTokenArr[0];
+    const m = /^\$\[(\d+)\]$/.exec(path);
+    if (m) return vpTokenArr[Number(m[1])];
+    throw new Error(`unsupported presentation_submission path: ${path}`);
+  }
+
+  // Decodes one layer of a W3C VP wrapper so path_nested can descend into
+  // its embedded credentials — compact JWT-VP -> its claims payload, plain
+  // ldp_vc VP object -> itself. mso_mdoc/SD-JWT+KB are rejected before
+  // reaching here (path_nested doesn't apply to non-VP-wrapping formats).
+  private decodeForTraversal(entry: any): any {
+    if (typeof entry === 'string') {
+      const claims: any = jose.decodeJwt(entry);
+      return claims.vp || claims;
+    }
+    return entry;
   }
 
   async getStatus(id: string) {

--- a/services/oid4vc-service/src/oid4vp/pex.service.spec.ts
+++ b/services/oid4vc-service/src/oid4vp/pex.service.spec.ts
@@ -1,0 +1,185 @@
+import { PexService } from './pex.service';
+
+describe('PexService', () => {
+  const pex = new PexService();
+
+  const presented = [
+    {
+      types: ['VerifiableCredential', 'TeacherCredential'],
+      vct: 'TeacherCredential',
+      format: 'jwt_vc_json',
+      claims: { name: 'Alice', qualification: 'B.Ed', dob: '1990-01-01' },
+    },
+  ];
+
+  const mdocPresented = [
+    {
+      types: [],
+      docType: 'org.iso.18013.5.1.mDL',
+      format: 'mso_mdoc',
+      claims: { 'org.iso.18013.5.1': { given_name: 'Alice' } },
+    },
+  ];
+
+  it('matches by field path and discloses the requested field', () => {
+    const definition = {
+      input_descriptors: [
+        {
+          id: 'teacher',
+          constraints: { fields: [{ path: ['$.credentialSubject.qualification'] }] },
+        },
+      ],
+    };
+    const res = pex.evaluate(definition, presented);
+    expect(res.satisfied).toBe(true);
+    expect(res.matched.teacher).toEqual({ qualification: 'B.Ed' });
+  });
+
+  it('enforces filter.const', () => {
+    const definition = {
+      input_descriptors: [
+        {
+          id: 'teacher',
+          constraints: {
+            fields: [{ path: ['$.credentialSubject.qualification'], filter: { const: 'PhD' } }],
+          },
+        },
+      ],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('enforces filter.enum and filter.pattern', () => {
+    const enumDef = {
+      input_descriptors: [
+        { id: 'teacher', constraints: { fields: [{ path: ['$.credentialSubject.qualification'], filter: { enum: ['B.Ed', 'M.Ed'] } }] } },
+      ],
+    };
+    expect(pex.evaluate(enumDef, presented).satisfied).toBe(true);
+
+    const patternDef = {
+      input_descriptors: [
+        { id: 'teacher', constraints: { fields: [{ path: ['$.credentialSubject.dob'], filter: { pattern: '^1990' } }] } },
+      ],
+    };
+    expect(pex.evaluate(patternDef, presented).satisfied).toBe(true);
+  });
+
+  it('fails closed on an unsupported filter keyword', () => {
+    const definition = {
+      input_descriptors: [
+        { id: 'teacher', constraints: { fields: [{ path: ['$.credentialSubject.qualification'], filter: { minimum: 1 } }] } },
+      ],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('rejects when format restriction excludes the candidate', () => {
+    const definition = {
+      input_descriptors: [{ id: 'teacher', format: { mso_mdoc: {} }, constraints: { fields: [] } }],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('fails when a required field is missing', () => {
+    const definition = {
+      input_descriptors: [{ id: 'teacher', constraints: { fields: [{ path: ['$.credentialSubject.salary'] }] } }],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('an optional missing field does not fail the descriptor', () => {
+    const definition = {
+      input_descriptors: [
+        {
+          id: 'teacher',
+          constraints: {
+            fields: [
+              { path: ['$.credentialSubject.qualification'] },
+              { path: ['$.credentialSubject.salary'], optional: true },
+            ],
+          },
+        },
+      ],
+    };
+    const res = pex.evaluate(definition, presented);
+    expect(res.satisfied).toBe(true);
+    expect(res.matched.teacher).toEqual({ qualification: 'B.Ed' });
+  });
+
+  it('resolves bracket-notation paths against mdoc namespace keys', () => {
+    const definition = {
+      input_descriptors: [
+        {
+          id: 'mdl',
+          format: { mso_mdoc: {} },
+          constraints: { fields: [{ path: ["$['org.iso.18013.5.1']['given_name']"] }] },
+        },
+      ],
+    };
+    const res = pex.evaluate(definition, mdocPresented);
+    expect(res.satisfied).toBe(true);
+    expect(res.matched.mdl).toEqual({ "org.iso.18013.5.1.given_name": 'Alice' });
+  });
+
+  it('rejects an empty presentation_definition', () => {
+    expect(pex.evaluate({ input_descriptors: [] }, presented).satisfied).toBe(false);
+  });
+
+  it('without submission_requirements, every descriptor is mandatory', () => {
+    const definition = {
+      input_descriptors: [
+        { id: 'teacher', constraints: { fields: [{ path: ['$.credentialSubject.name'] }] } },
+        { id: 'x', format: { mso_mdoc: {} }, constraints: { fields: [] } },
+      ],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('submission_requirements rule "pick" allows a subset of a group', () => {
+    const definition = {
+      input_descriptors: [
+        { id: 'teacher', group: ['g'], constraints: { fields: [{ path: ['$.credentialSubject.name'] }] } },
+        { id: 'never-presented', group: ['g'], format: { mso_mdoc: {} }, constraints: { fields: [] } },
+      ],
+      submission_requirements: [{ rule: 'pick', count: 1, from: 'g' }],
+    };
+    const res = pex.evaluate(definition, presented);
+    expect(res.satisfied).toBe(true);
+    expect(res.matched.teacher).toEqual({ name: 'Alice' });
+    expect(res.matched['never-presented']).toBeUndefined();
+  });
+
+  it('submission_requirements rule "all" requires every descriptor in the group', () => {
+    const definition = {
+      input_descriptors: [
+        { id: 'teacher', group: ['g'], constraints: { fields: [{ path: ['$.credentialSubject.name'] }] } },
+        { id: 'never-presented', group: ['g'], format: { mso_mdoc: {} }, constraints: { fields: [] } },
+      ],
+      submission_requirements: [{ rule: 'all', from: 'g' }],
+    };
+    expect(pex.evaluate(definition, presented).satisfied).toBe(false);
+  });
+
+  it('submission_requirements from_nested combines nested group results', () => {
+    const definition = {
+      input_descriptors: [
+        { id: 'teacher', group: ['a'], constraints: { fields: [{ path: ['$.credentialSubject.name'] }] } },
+        { id: 'never-presented', group: ['b'], format: { mso_mdoc: {} }, constraints: { fields: [] } },
+      ],
+      submission_requirements: [
+        {
+          rule: 'pick',
+          count: 1,
+          from_nested: [
+            { rule: 'all', from: 'a' },
+            { rule: 'all', from: 'b' },
+          ],
+        },
+      ],
+    };
+    const res = pex.evaluate(definition, presented);
+    expect(res.satisfied).toBe(true);
+    expect(res.matched.teacher).toEqual({ name: 'Alice' });
+  });
+});

--- a/services/oid4vc-service/src/oid4vp/pex.service.ts
+++ b/services/oid4vc-service/src/oid4vp/pex.service.ts
@@ -1,0 +1,193 @@
+import { Injectable } from '@nestjs/common';
+import { sameFormat } from './dcql.service';
+import { parseJsonPath, walkSegments } from './jsonpath.util';
+
+type Presented = {
+  types: string[];
+  vct?: string;
+  docType?: string;
+  format: string;
+  claims: Record<string, any>;
+};
+
+type DescriptorResult = { matched: boolean; disclosed?: Record<string, any>; consumedIdx?: number };
+
+// DIF Presentation Exchange v2.0 evaluator. Covers input_descriptors[]
+// constraints.fields path+filter matching, format restriction, and
+// submission_requirements pick/all groups (including from_nested).
+//
+// A presentation_definition looks like:
+//   { input_descriptors: [ { id, format?, group?, constraints: { fields: [
+//       { path: [...alternatives], filter?, optional? } ] } } ],
+//     submission_requirements?: [ { rule: 'all'|'pick', from?, from_nested?, count?, min?, max? } ] }
+@Injectable()
+export class PexService {
+  // Returns { satisfied, matched: { [input_descriptor.id]: disclosedClaims } }.
+  evaluate(
+    presentationDefinition: any,
+    presented: Presented[],
+  ): { satisfied: boolean; matched: Record<string, any>; reason?: string } {
+    const descriptors = presentationDefinition?.input_descriptors;
+    if (!Array.isArray(descriptors) || descriptors.length === 0) {
+      return { satisfied: false, matched: {}, reason: 'empty presentation_definition' };
+    }
+
+    // Attempt every descriptor greedily (first-fit against not-yet-consumed
+    // presented entries), regardless of submission_requirements — the
+    // requirement tree below decides which of these attempts actually needed
+    // to succeed. Non-backtracking: once a presented entry is consumed by a
+    // descriptor, no earlier descriptor gets a chance to reclaim it.
+    const consumed = new Set<number>();
+    const results = new Map<string, DescriptorResult>();
+    for (const desc of descriptors) {
+      let foundIdx = -1;
+      let foundDisclosed: Record<string, any> | undefined;
+      for (let i = 0; i < presented.length; i++) {
+        if (consumed.has(i)) continue;
+        const disclosed = this.matchDescriptor(desc, presented[i]);
+        if (disclosed !== undefined) {
+          foundIdx = i;
+          foundDisclosed = disclosed;
+          break;
+        }
+      }
+      if (foundIdx === -1) {
+        results.set(desc.id, { matched: false });
+        continue;
+      }
+      consumed.add(foundIdx);
+      results.set(desc.id, { matched: true, disclosed: foundDisclosed, consumedIdx: foundIdx });
+    }
+
+    const requirements = presentationDefinition?.submission_requirements;
+    if (!Array.isArray(requirements) || requirements.length === 0) {
+      // No submission_requirements → every descriptor is mandatory (DCQL parity).
+      for (const desc of descriptors) {
+        if (!results.get(desc.id)?.matched) {
+          return { satisfied: false, matched: {}, reason: `no credential matched input_descriptor ${desc.id}` };
+        }
+      }
+      const matched: Record<string, any> = {};
+      for (const desc of descriptors) matched[desc.id] = results.get(desc.id)!.disclosed;
+      return { satisfied: true, matched };
+    }
+
+    // submission_requirements present: top-level entries are ANDed together
+    // (DIF PEX v2.0 §submission_requirements).
+    const groupOf = new Map<string, string[]>(); // group tag -> descriptor ids tagged with it
+    for (const desc of descriptors) {
+      for (const g of desc.group || []) {
+        if (!groupOf.has(g)) groupOf.set(g, []);
+        groupOf.get(g)!.push(desc.id);
+      }
+    }
+
+    const usedIds = new Set<string>();
+    for (const req of requirements) {
+      const result = this.evaluateRequirement(req, results, groupOf);
+      if (!result.ok) {
+        return {
+          satisfied: false,
+          matched: {},
+          reason: `submission_requirements not satisfied: ${req.name || req.from || 'group'}`,
+        };
+      }
+      result.usedIds.forEach((id) => usedIds.add(id));
+    }
+
+    const matched: Record<string, any> = {};
+    for (const id of usedIds) matched[id] = results.get(id)?.disclosed;
+    return { satisfied: true, matched };
+  }
+
+  private evaluateRequirement(
+    req: any,
+    results: Map<string, DescriptorResult>,
+    groupOf: Map<string, string[]>,
+  ): { ok: boolean; usedIds: string[] } {
+    if (req.from) {
+      const ids = groupOf.get(req.from) || [];
+      const satisfiedIds = ids.filter((id) => results.get(id)?.matched);
+      const ok = this.countSatisfiesRule(req, satisfiedIds.length, ids.length);
+      return { ok, usedIds: ok ? satisfiedIds : [] };
+    }
+    if (Array.isArray(req.from_nested)) {
+      const nestedResults = req.from_nested.map((r: any) => this.evaluateRequirement(r, results, groupOf));
+      const passingCount = nestedResults.filter((r: { ok: boolean }) => r.ok).length;
+      const ok = this.countSatisfiesRule(req, passingCount, nestedResults.length);
+      const usedIds = ok
+        ? nestedResults.filter((r: { ok: boolean }) => r.ok).flatMap((r: { usedIds: string[] }) => r.usedIds)
+        : [];
+      return { ok, usedIds };
+    }
+    return { ok: false, usedIds: [] };
+  }
+
+  private countSatisfiesRule(req: any, n: number, total: number): boolean {
+    if (req.rule === 'all') return n === total;
+    // rule === 'pick'
+    const count = req.count;
+    const min = req.min ?? (count !== undefined ? count : 1);
+    const max = req.max ?? (count !== undefined ? count : total);
+    return n >= min && n <= max;
+  }
+
+  // Returns the disclosed-claims map if `desc` matches `p`, else undefined.
+  private matchDescriptor(desc: any, p: Presented): Record<string, any> | undefined {
+    const formatKeys = desc.format ? Object.keys(desc.format) : [];
+    if (formatKeys.length && !formatKeys.some((f) => sameFormat(f, p.format))) return undefined;
+
+    const fields = desc.constraints?.fields || [];
+    if (!fields.length) return p.claims;
+
+    const disclosed: Record<string, any> = {};
+    for (const field of fields) {
+      const resolved = this.resolveField(field, p);
+      if (resolved === undefined) {
+        if (field.optional) continue;
+        return undefined;
+      }
+      if (!this.matchesFilter(field.filter, resolved.value)) return undefined;
+      disclosed[resolved.key] = resolved.value;
+    }
+    return disclosed;
+  }
+
+  private resolveField(field: any, p: Presented): { key: string; value: any } | undefined {
+    const paths: string[] = field.path || [];
+    for (const path of paths) {
+      const segments = this.stripWrapperSegments(path, p.format);
+      const value = walkSegments(p.claims, segments);
+      if (value !== undefined) return { key: segments.join('.'), value };
+    }
+    return undefined;
+  }
+
+  // p.claims is already the pre-unwrapped credentialSubject object (see
+  // extractCredentials() in oid4vp.service.ts), but a field path is written
+  // against the full credential shape — strip a leading vc/credentialSubject
+  // segment for W3C VC formats before resolving against p.claims.
+  private stripWrapperSegments(path: string, format: string): Array<string | number> {
+    let segments = parseJsonPath(path);
+    if (format === 'jwt_vc_json' || format === 'ldp_vc') {
+      if (segments[0] === 'vc') segments = segments.slice(1);
+      if (segments[0] === 'credentialSubject') segments = segments.slice(1);
+    }
+    return segments;
+  }
+
+  // filter subset: const (equality), enum (membership), pattern (regex).
+  // Unknown keyword → fails closed (treated as non-matching), not silently
+  // ignored.
+  // ponytail: const/enum/pattern only — add via a real JSON-schema validator
+  // (ajv) if a producer's definition ever needs allOf/minimum/format/etc.
+  private matchesFilter(filter: any, value: any): boolean {
+    if (!filter) return true;
+    const keys = Object.keys(filter);
+    if (keys.some((k) => !['const', 'enum', 'pattern'].includes(k))) return false;
+    if ('const' in filter && value !== filter.const) return false;
+    if ('enum' in filter && !filter.enum.includes(value)) return false;
+    if ('pattern' in filter && !new RegExp(filter.pattern).test(String(value))) return false;
+    return true;
+  }
+}


### PR DESCRIPTION
## Description

Adds DIF Presentation Exchange (PEX) v2.0 support to `oid4vc-service`'s OID4VP verifier flow, as an alternative query language to the existing DCQL-only implementation. Enables live VP round trips against wallets (e.g. Inji) that implement PEX but not DCQL. Also fixes real holder-binding and key-selection bugs surfaced by testing against a live wallet, and adds `JsonWebSignature2020` proof verification + local `did:jwk` resolution to `credentials-service`.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / Technical Debt
- [x] Test case addition/update

## Microservice(s) Affected

- [x] `oid4vc-service`
- [x] `credentials-service`

## Changes

**`oid4vc-service` — PEX support:**
- New `PexService` (`pex.service.ts`): full DIF PEX v2.0 evaluator — `input_descriptors[].constraints.fields` path/filter matching, format restriction, `submission_requirements` (`pick`/`all`, `from`/`from_nested`)
- New shared `jsonpath.util.ts`: minimal JSONPath subset (dot/bracket segments, numeric indices) used by both `PexService` and descriptor-map resolution
- `oid4vp.service.ts`: `VpTxn.queryMode: 'dcql' | 'pex'` — request accepts `presentation_definition` as a mutually-exclusive alternative to `dcql_query`; `submitResponse()` branches per mode; per-credential verification extracted into a shared `verifyPresentationEntry()` used by both DCQL and PEX loops
- `resolveDescriptorMapEntry()`: resolves `descriptor_map[].path` / `path_nested` chains against the wallet's `vp_token`
- `normalizePexVpToken()`: absorbs PEX's `vp_token` shape (raw presentation, not always JSON, unlike DCQL's always-object shape)

**Bug fixes (found via live wallet testing):**
- `resolveDescriptorMapEntry()` no longer descends into `path_nested` when the outer format is `ldp_vp` — descending discarded the outer VP's holder-binding proof and exposed only the embedded VC's static issuance-time proof
- Holder DID comparison strips the verification-method `#fragment` (`did:jwk:...#0` vs the bare DID) before comparing to `credentialSubject.id`
- `oid4vci.service.ts`: issuer metadata now advertises `EdDSA` in `proof_types_supported.jwt.proof_signing_alg_values_supported` (previously `ES256` only) — some wallets hardcode Ed25519 for presentation-signing independent of their issuance-time key selection, so the issuer must advertise EdDSA for that key to ever be selectable at issuance

**`credentials-service`:**
- `verifyCredential()` dispatches to a new `verifyPresentation()` path when `type` includes `VerifiablePresentation`, instead of only ever treating the body as a bare VC
- New `jws2020.util.ts`: hand-rolled `JsonWebSignature2020` Linked-Data proof verifier (URDNA2015 canonicalization + detached JWS per RFC7797) — no installed suite covers this proof type
- New `self-contained-did.util.ts`: local `did:jwk` resolution (public key is the DID's own base64url JWK payload, no network lookup)

## Notes

- No new runtime dependency — PEX evaluator is hand-rolled, mirroring `DcqlService`'s existing non-library approach
- No schema/DB change, no new top-level API route — `presentation_definition` is an additive, mutually-exclusive alternative field on the existing `POST /vp/request` body
- Three behavior changes affect pre-existing DCQL callers, not just new PEX requests (detailed in the design doc): QR/`qr_data` link is now returned by-value instead of always by-reference; issued VC `@context` now rewrites `internalUrl` → `publicUrl` for all issuance; `ldp_vc` plain-VP-object holder binding is stricter (`credentialSubject.id` must equal the VP's `holder`, not merely exist)
